### PR TITLE
Adjusts component and story to style slotted contents externally

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -79,7 +79,7 @@
               "type": {
                 "text": "\"primary\" | \"secondary\" | \"tertiary\""
               },
-              "description": "Optional button style,\r\ncan be either primary, secondary or tertiary and defaults to primary if not specified",
+              "description": "Optional button style,\ncan be either primary, secondary or tertiary and defaults to primary if not specified",
               "default": "'primary'",
               "required": false
             }
@@ -353,7 +353,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "If true, will allow the user to take a snapshot\r\nusing the device camera. (only works over https).",
+              "description": "If true, will allow the user to take a snapshot\nusing the device camera. (only works over https).",
               "default": "false",
               "required": false
             },
@@ -362,7 +362,7 @@
               "type": {
                 "text": "number"
               },
-              "description": "Specifies the jpeg quality for when the device\r\ncamera is used to generate a picture.\r\nNeeds to be a number between 0 and 1 and defaults to 0.8",
+              "description": "Specifies the jpeg quality for when the device\ncamera is used to generate a picture.\nNeeds to be a number between 0 and 1 and defaults to 0.8",
               "default": "0.8",
               "required": false
             }
@@ -374,7 +374,7 @@
               "type": {
                 "text": "string[]"
               },
-              "description": "A list of allowed file extensions.\r\nIf not specified, any file is allowed.\r\nEx: [\"jpg\", \"jped\", \"gif\", \"png\"]",
+              "description": "A list of allowed file extensions.\nIf not specified, any file is allowed.\nEx: [\"jpg\", \"jped\", \"gif\", \"png\"]",
               "required": false
             },
             {
@@ -384,7 +384,7 @@
                 "text": "{ dragAndDropFile: string; capture: string; or: string; takePicture: string; uploadFile: string; }"
               },
               "description": "Localization strings",
-              "default": "{\r\n    dragAndDropFile: \"Drag and drop a file\",\r\n    capture: \"Capture\",\r\n    or: \"or\",\r\n    takePicture: \"Take a picture\",\r\n    uploadFile: \"Upload a file\",\r\n  }",
+              "default": "{\n    dragAndDropFile: \"Drag and drop a file\",\n    capture: \"Capture\",\n    or: \"or\",\n    takePicture: \"Take a picture\",\n    uploadFile: \"Upload a file\",\n  }",
               "required": false
             }
           ],
@@ -424,7 +424,7 @@
           "kind": "class",
           "name": "dnn-image-cropper.tsx",
           "tagName": "dnn-image-cropper",
-          "description": "Allows cropping an image in-browser with the option to enforce a specific final size.\r\nAll computation happens in the browser and the final image is emmited\r\nin an event that has a data-url of the image.",
+          "description": "Allows cropping an image in-browser with the option to enforce a specific final size.\nAll computation happens in the browser and the final image is emmited\nin an event that has a data-url of the image.",
           "attributes": [
             {
               "name": "height",
@@ -470,8 +470,8 @@
               "type": {
                 "text": "{ capture: string; dragAndDropFile: string; or: string; takePicture: string; uploadFile: string; imageTooSmall: string; modalCloseText: string; }"
               },
-              "description": "Can be used to customize controls text.\r\nSome values support tokens, see default values for examples.",
-              "default": "{\r\n    capture: \"Capture\",\r\n    dragAndDropFile: \"Drag and drop an image\",\r\n    or: \"or\",\r\n    takePicture: \"Take a picture\",\r\n    uploadFile: \"Upload an image\",\r\n    imageTooSmall: \"The image you are attempting to upload does not meet the minimum size requirement of {width} pixels by {height} pixels. Please upload a larger image.\",\r\n    modalCloseText: \"Close\",\r\n  }",
+              "description": "Can be used to customize controls text.\nSome values support tokens, see default values for examples.",
+              "default": "{\n    capture: \"Capture\",\n    dragAndDropFile: \"Drag and drop an image\",\n    or: \"or\",\n    takePicture: \"Take a picture\",\n    uploadFile: \"Upload an image\",\n    imageTooSmall: \"The image you are attempting to upload does not meet the minimum size requirement of {width} pixels by {height} pixels. Please upload a larger image.\",\n    modalCloseText: \"Close\",\n  }",
               "required": false
             }
           ],
@@ -514,7 +514,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Optionally pass the aria-label text for the close button.\r\nDefaults to \"Close modal\" if not provided.",
+              "description": "Optionally pass the aria-label text for the close button.\nDefaults to \"Close modal\" if not provided.",
               "default": "\"Close modal\"",
               "required": false
             },
@@ -523,7 +523,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "Optionally you can pass false to not show the close button.\r\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\r\nor provide your own dismissal logic in the modal content.",
+              "description": "Optionally you can pass false to not show the close button.\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\nor provide your own dismissal logic in the modal content.",
               "default": "true",
               "required": false
             },
@@ -608,7 +608,7 @@
                 "text": "ILocalization"
               },
               "description": "Optionally allows localizing the component strings.",
-              "default": "{\r\n    Add: \"Add\",\r\n    AllRoles: \"All Roles\",\r\n    FilterByGroup: \"Filter By Group\",\r\n    GlobalRoles: \"Global Roles\",\r\n    Role: \"Role\",\r\n    RolePermissions: \"Role Permissions\",\r\n    SelectRole: \"Select Role\",\r\n    User: \"User\",\r\n    UserPermissions: \"User Permissions\",\r\n  }",
+              "default": "{\n    Add: \"Add\",\n    AllRoles: \"All Roles\",\n    FilterByGroup: \"Filter By Group\",\n    GlobalRoles: \"Global Roles\",\n    Role: \"Role\",\n    RolePermissions: \"Role Permissions\",\n    SelectRole: \"Select Role\",\n    User: \"User\",\n    UserPermissions: \"User Permissions\",\n  }",
               "required": false
             },
             {
@@ -697,7 +697,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Fires up each time the search query changes.\r\nThe data passed is the new query."
+              "description": "Fires up each time the search query changes.\nThe data passed is the new query."
             }
           ],
           "slots": [],
@@ -972,15 +972,11 @@
           "cssProperties": [
             {
               "name": "--background-color",
-              "description": "Defines the menu background color"
+              "description": "Defines the menu background color."
             },
             {
               "name": "--foreground-color",
-              "description": "A color that contrasts with the background color"
-            },
-            {
-              "name": "--text-color",
-              "description": "The color of the text"
+              "description": "A color that contrasts with the background color."
             }
           ],
           "cssParts": []
@@ -995,7 +991,7 @@
           "kind": "class",
           "name": "dnn-vertical-splitview.tsx",
           "tagName": "dnn-vertical-splitview",
-          "description": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\r\n- The content for the left part should be injected in the `left` slot.\r\n- The content for the right part should be injected in the `right` slot.\r\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component.",
+          "description": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\n- The content for the left part should be injected in the `left` slot.\n- The content for the right part should be injected in the `right` slot.\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component.",
           "attributes": [
             {
               "name": "split-width-percentage",

--- a/licenses.txt
+++ b/licenses.txt
@@ -3,795 +3,795 @@
 │  ├─ repository: https://github.com/ampproject/remapping
 │  ├─ publisher: Justin Ridgewell
 │  ├─ email: jridgewell@google.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\@ampproject\remapping
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@ampproject\remapping
 │  └─ licenseFile: node_modules\@ampproject\remapping\LICENSE
 ├─ @babel/code-frame@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\code-frame
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\code-frame
 │  └─ licenseFile: node_modules\@babel\code-frame\LICENSE
-├─ @babel/compat-data@7.17.0
+├─ @babel/compat-data@7.17.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\compat-data
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\compat-data
 │  └─ licenseFile: node_modules\@babel\compat-data\LICENSE
-├─ @babel/core@7.17.5
+├─ @babel/core@7.17.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\core
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\core
 │  └─ licenseFile: node_modules\@babel\core\LICENSE
-├─ @babel/generator@7.17.3
+├─ @babel/generator@7.17.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\generator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\generator
 │  └─ licenseFile: node_modules\@babel\generator\LICENSE
 ├─ @babel/helper-annotate-as-pure@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-annotate-as-pure
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-annotate-as-pure
 │  └─ licenseFile: node_modules\@babel\helper-annotate-as-pure\LICENSE
 ├─ @babel/helper-builder-binary-assignment-operator-visitor@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-builder-binary-assignment-operator-visitor
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-builder-binary-assignment-operator-visitor
 │  └─ licenseFile: node_modules\@babel\helper-builder-binary-assignment-operator-visitor\LICENSE
-├─ @babel/helper-compilation-targets@7.16.7
+├─ @babel/helper-compilation-targets@7.17.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-compilation-targets
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-compilation-targets
 │  └─ licenseFile: node_modules\@babel\helper-compilation-targets\LICENSE
 ├─ @babel/helper-create-class-features-plugin@7.17.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-create-class-features-plugin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-create-class-features-plugin
 │  └─ licenseFile: node_modules\@babel\helper-create-class-features-plugin\LICENSE
 ├─ @babel/helper-create-regexp-features-plugin@7.17.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-create-regexp-features-plugin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-create-regexp-features-plugin
 │  └─ licenseFile: node_modules\@babel\helper-create-regexp-features-plugin\LICENSE
 ├─ @babel/helper-define-polyfill-provider@0.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel-polyfills
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-define-polyfill-provider
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-define-polyfill-provider
 │  └─ licenseFile: node_modules\@babel\helper-define-polyfill-provider\LICENSE
 ├─ @babel/helper-environment-visitor@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-environment-visitor
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-environment-visitor
 │  └─ licenseFile: node_modules\@babel\helper-environment-visitor\LICENSE
 ├─ @babel/helper-explode-assignable-expression@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-explode-assignable-expression
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-explode-assignable-expression
 │  └─ licenseFile: node_modules\@babel\helper-explode-assignable-expression\LICENSE
 ├─ @babel/helper-function-name@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-function-name
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-function-name
 │  └─ licenseFile: node_modules\@babel\helper-function-name\LICENSE
 ├─ @babel/helper-get-function-arity@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-get-function-arity
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-get-function-arity
 │  └─ licenseFile: node_modules\@babel\helper-get-function-arity\LICENSE
 ├─ @babel/helper-hoist-variables@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-hoist-variables
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-hoist-variables
 │  └─ licenseFile: node_modules\@babel\helper-hoist-variables\LICENSE
-├─ @babel/helper-member-expression-to-functions@7.16.7
+├─ @babel/helper-member-expression-to-functions@7.17.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-member-expression-to-functions
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-member-expression-to-functions
 │  └─ licenseFile: node_modules\@babel\helper-member-expression-to-functions\LICENSE
 ├─ @babel/helper-module-imports@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-module-imports
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-module-imports
 │  └─ licenseFile: node_modules\@babel\helper-module-imports\LICENSE
-├─ @babel/helper-module-transforms@7.17.6
+├─ @babel/helper-module-transforms@7.17.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-module-transforms
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-module-transforms
 │  └─ licenseFile: node_modules\@babel\helper-module-transforms\LICENSE
 ├─ @babel/helper-optimise-call-expression@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-optimise-call-expression
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-optimise-call-expression
 │  └─ licenseFile: node_modules\@babel\helper-optimise-call-expression\LICENSE
 ├─ @babel/helper-plugin-utils@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-plugin-utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-plugin-utils
 │  └─ licenseFile: node_modules\@babel\helper-plugin-utils\LICENSE
 ├─ @babel/helper-remap-async-to-generator@7.16.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-remap-async-to-generator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-remap-async-to-generator
 │  └─ licenseFile: node_modules\@babel\helper-remap-async-to-generator\LICENSE
 ├─ @babel/helper-replace-supers@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-replace-supers
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-replace-supers
 │  └─ licenseFile: node_modules\@babel\helper-replace-supers\LICENSE
-├─ @babel/helper-simple-access@7.16.7
+├─ @babel/helper-simple-access@7.17.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-simple-access
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-simple-access
 │  └─ licenseFile: node_modules\@babel\helper-simple-access\LICENSE
 ├─ @babel/helper-skip-transparent-expression-wrappers@7.16.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-skip-transparent-expression-wrappers
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-skip-transparent-expression-wrappers
 │  └─ licenseFile: node_modules\@babel\helper-skip-transparent-expression-wrappers\LICENSE
 ├─ @babel/helper-split-export-declaration@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-split-export-declaration
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-split-export-declaration
 │  └─ licenseFile: node_modules\@babel\helper-split-export-declaration\LICENSE
 ├─ @babel/helper-validator-identifier@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-validator-identifier
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-validator-identifier
 │  └─ licenseFile: node_modules\@babel\helper-validator-identifier\LICENSE
 ├─ @babel/helper-validator-option@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-validator-option
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-validator-option
 │  └─ licenseFile: node_modules\@babel\helper-validator-option\LICENSE
 ├─ @babel/helper-wrap-function@7.16.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helper-wrap-function
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helper-wrap-function
 │  └─ licenseFile: node_modules\@babel\helper-wrap-function\LICENSE
-├─ @babel/helpers@7.17.2
+├─ @babel/helpers@7.17.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\helpers
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\helpers
 │  └─ licenseFile: node_modules\@babel\helpers\LICENSE
 ├─ @babel/highlight@7.16.10
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\highlight
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\highlight
 │  └─ licenseFile: node_modules\@babel\highlight\LICENSE
-├─ @babel/parser@7.17.3
+├─ @babel/parser@7.17.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\parser
 │  └─ licenseFile: node_modules\@babel\parser\LICENSE
 ├─ @babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-bugfix-safari-id-destructuring-collision-in-function-expression
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-bugfix-safari-id-destructuring-collision-in-function-expression
 │  └─ licenseFile: node_modules\@babel\plugin-bugfix-safari-id-destructuring-collision-in-function-expression\LICENSE
 ├─ @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-bugfix-v8-spread-parameters-in-optional-chaining
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-bugfix-v8-spread-parameters-in-optional-chaining
 │  └─ licenseFile: node_modules\@babel\plugin-bugfix-v8-spread-parameters-in-optional-chaining\LICENSE
 ├─ @babel/plugin-proposal-async-generator-functions@7.16.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-async-generator-functions
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-async-generator-functions
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-async-generator-functions\LICENSE
 ├─ @babel/plugin-proposal-class-properties@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-class-properties
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-class-properties
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-class-properties\LICENSE
 ├─ @babel/plugin-proposal-class-static-block@7.17.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-class-static-block
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-class-static-block
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-class-static-block\LICENSE
-├─ @babel/plugin-proposal-decorators@7.17.2
+├─ @babel/plugin-proposal-decorators@7.17.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-decorators
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-decorators
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-decorators\LICENSE
 ├─ @babel/plugin-proposal-dynamic-import@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-dynamic-import
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-dynamic-import
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-dynamic-import\LICENSE
 ├─ @babel/plugin-proposal-export-default-from@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-export-default-from
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-export-default-from
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-export-default-from\LICENSE
 ├─ @babel/plugin-proposal-export-namespace-from@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-export-namespace-from
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-export-namespace-from
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-export-namespace-from\LICENSE
 ├─ @babel/plugin-proposal-json-strings@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-json-strings
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-json-strings
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-json-strings\LICENSE
 ├─ @babel/plugin-proposal-logical-assignment-operators@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-logical-assignment-operators
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-logical-assignment-operators
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-logical-assignment-operators\LICENSE
 ├─ @babel/plugin-proposal-nullish-coalescing-operator@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-nullish-coalescing-operator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-nullish-coalescing-operator
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-nullish-coalescing-operator\LICENSE
 ├─ @babel/plugin-proposal-numeric-separator@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-numeric-separator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-numeric-separator
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-numeric-separator\LICENSE
 ├─ @babel/plugin-proposal-object-rest-spread@7.17.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-object-rest-spread
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-object-rest-spread
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-object-rest-spread\LICENSE
 ├─ @babel/plugin-proposal-optional-catch-binding@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-optional-catch-binding
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-optional-catch-binding
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-optional-catch-binding\LICENSE
 ├─ @babel/plugin-proposal-optional-chaining@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-optional-chaining
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-optional-chaining
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-optional-chaining\LICENSE
 ├─ @babel/plugin-proposal-private-methods@7.16.11
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-private-methods
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-private-methods
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-private-methods\LICENSE
 ├─ @babel/plugin-proposal-private-property-in-object@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-private-property-in-object
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-private-property-in-object
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-private-property-in-object\LICENSE
 ├─ @babel/plugin-proposal-unicode-property-regex@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-proposal-unicode-property-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-proposal-unicode-property-regex
 │  └─ licenseFile: node_modules\@babel\plugin-proposal-unicode-property-regex\LICENSE
 ├─ @babel/plugin-syntax-async-generators@7.8.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-async-generators
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-async-generators
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-async-generators\LICENSE
 ├─ @babel/plugin-syntax-bigint@7.8.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-bigint
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-bigint
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-bigint
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-bigint\LICENSE
 ├─ @babel/plugin-syntax-class-properties@7.12.13
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-class-properties
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-class-properties
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-class-properties\LICENSE
 ├─ @babel/plugin-syntax-class-static-block@7.14.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-class-static-block
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-class-static-block
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-class-static-block\LICENSE
 ├─ @babel/plugin-syntax-decorators@7.17.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-decorators
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-decorators
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-decorators\LICENSE
 ├─ @babel/plugin-syntax-dynamic-import@7.8.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-dynamic-import
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-dynamic-import
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-dynamic-import\LICENSE
 ├─ @babel/plugin-syntax-export-default-from@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-export-default-from
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-export-default-from
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-export-default-from\LICENSE
 ├─ @babel/plugin-syntax-export-namespace-from@7.8.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-export-namespace-from
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-export-namespace-from
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-export-namespace-from\LICENSE
 ├─ @babel/plugin-syntax-import-meta@7.10.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-import-meta
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-import-meta
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-import-meta\LICENSE
 ├─ @babel/plugin-syntax-json-strings@7.8.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-json-strings
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-json-strings
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-json-strings\LICENSE
 ├─ @babel/plugin-syntax-jsx@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-jsx
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-jsx
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-jsx\LICENSE
 ├─ @babel/plugin-syntax-logical-assignment-operators@7.10.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-logical-assignment-operators
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-logical-assignment-operators
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-logical-assignment-operators\LICENSE
 ├─ @babel/plugin-syntax-nullish-coalescing-operator@7.8.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-nullish-coalescing-operator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-nullish-coalescing-operator
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-nullish-coalescing-operator\LICENSE
 ├─ @babel/plugin-syntax-numeric-separator@7.10.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-numeric-separator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-numeric-separator
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-numeric-separator\LICENSE
 ├─ @babel/plugin-syntax-object-rest-spread@7.8.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-object-rest-spread
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-object-rest-spread
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-object-rest-spread\LICENSE
 ├─ @babel/plugin-syntax-optional-catch-binding@7.8.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-optional-catch-binding
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-optional-catch-binding
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-optional-catch-binding\LICENSE
 ├─ @babel/plugin-syntax-optional-chaining@7.8.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-optional-chaining
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-optional-chaining
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-optional-chaining\LICENSE
 ├─ @babel/plugin-syntax-private-property-in-object@7.14.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-private-property-in-object
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-private-property-in-object
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-private-property-in-object\LICENSE
 ├─ @babel/plugin-syntax-top-level-await@7.14.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-top-level-await
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-top-level-await
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-top-level-await\LICENSE
 ├─ @babel/plugin-syntax-typescript@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-syntax-typescript
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-syntax-typescript
 │  └─ licenseFile: node_modules\@babel\plugin-syntax-typescript\LICENSE
 ├─ @babel/plugin-transform-arrow-functions@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-arrow-functions
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-arrow-functions
 │  └─ licenseFile: node_modules\@babel\plugin-transform-arrow-functions\LICENSE
 ├─ @babel/plugin-transform-async-to-generator@7.16.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-async-to-generator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-async-to-generator
 │  └─ licenseFile: node_modules\@babel\plugin-transform-async-to-generator\LICENSE
 ├─ @babel/plugin-transform-block-scoped-functions@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-block-scoped-functions
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-block-scoped-functions
 │  └─ licenseFile: node_modules\@babel\plugin-transform-block-scoped-functions\LICENSE
 ├─ @babel/plugin-transform-block-scoping@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-block-scoping
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-block-scoping
 │  └─ licenseFile: node_modules\@babel\plugin-transform-block-scoping\LICENSE
 ├─ @babel/plugin-transform-classes@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-classes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-classes
 │  └─ licenseFile: node_modules\@babel\plugin-transform-classes\LICENSE
 ├─ @babel/plugin-transform-computed-properties@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-computed-properties
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-computed-properties
 │  └─ licenseFile: node_modules\@babel\plugin-transform-computed-properties\LICENSE
-├─ @babel/plugin-transform-destructuring@7.17.3
+├─ @babel/plugin-transform-destructuring@7.17.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-destructuring
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-destructuring
 │  └─ licenseFile: node_modules\@babel\plugin-transform-destructuring\LICENSE
 ├─ @babel/plugin-transform-dotall-regex@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-dotall-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-dotall-regex
 │  └─ licenseFile: node_modules\@babel\plugin-transform-dotall-regex\LICENSE
 ├─ @babel/plugin-transform-duplicate-keys@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-duplicate-keys
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-duplicate-keys
 │  └─ licenseFile: node_modules\@babel\plugin-transform-duplicate-keys\LICENSE
 ├─ @babel/plugin-transform-exponentiation-operator@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-exponentiation-operator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-exponentiation-operator
 │  └─ licenseFile: node_modules\@babel\plugin-transform-exponentiation-operator\LICENSE
 ├─ @babel/plugin-transform-for-of@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-for-of
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-for-of
 │  └─ licenseFile: node_modules\@babel\plugin-transform-for-of\LICENSE
 ├─ @babel/plugin-transform-function-name@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-function-name
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-function-name
 │  └─ licenseFile: node_modules\@babel\plugin-transform-function-name\LICENSE
 ├─ @babel/plugin-transform-literals@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-literals
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-literals
 │  └─ licenseFile: node_modules\@babel\plugin-transform-literals\LICENSE
 ├─ @babel/plugin-transform-member-expression-literals@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-member-expression-literals
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-member-expression-literals
 │  └─ licenseFile: node_modules\@babel\plugin-transform-member-expression-literals\LICENSE
 ├─ @babel/plugin-transform-modules-amd@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-modules-amd
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-modules-amd
 │  └─ licenseFile: node_modules\@babel\plugin-transform-modules-amd\LICENSE
-├─ @babel/plugin-transform-modules-commonjs@7.16.8
+├─ @babel/plugin-transform-modules-commonjs@7.17.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-modules-commonjs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-modules-commonjs
 │  └─ licenseFile: node_modules\@babel\plugin-transform-modules-commonjs\LICENSE
-├─ @babel/plugin-transform-modules-systemjs@7.16.7
+├─ @babel/plugin-transform-modules-systemjs@7.17.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-modules-systemjs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-modules-systemjs
 │  └─ licenseFile: node_modules\@babel\plugin-transform-modules-systemjs\LICENSE
 ├─ @babel/plugin-transform-modules-umd@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-modules-umd
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-modules-umd
 │  └─ licenseFile: node_modules\@babel\plugin-transform-modules-umd\LICENSE
 ├─ @babel/plugin-transform-named-capturing-groups-regex@7.16.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-named-capturing-groups-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-named-capturing-groups-regex
 │  └─ licenseFile: node_modules\@babel\plugin-transform-named-capturing-groups-regex\LICENSE
 ├─ @babel/plugin-transform-new-target@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-new-target
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-new-target
 │  └─ licenseFile: node_modules\@babel\plugin-transform-new-target\LICENSE
 ├─ @babel/plugin-transform-object-super@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-object-super
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-object-super
 │  └─ licenseFile: node_modules\@babel\plugin-transform-object-super\LICENSE
 ├─ @babel/plugin-transform-parameters@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-parameters
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-parameters
 │  └─ licenseFile: node_modules\@babel\plugin-transform-parameters\LICENSE
 ├─ @babel/plugin-transform-property-literals@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-property-literals
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-property-literals
 │  └─ licenseFile: node_modules\@babel\plugin-transform-property-literals\LICENSE
 ├─ @babel/plugin-transform-react-display-name@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-react-display-name
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-react-display-name
 │  └─ licenseFile: node_modules\@babel\plugin-transform-react-display-name\LICENSE
 ├─ @babel/plugin-transform-react-jsx-development@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-react-jsx-development
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-react-jsx-development
 │  └─ licenseFile: node_modules\@babel\plugin-transform-react-jsx-development\LICENSE
 ├─ @babel/plugin-transform-react-jsx@7.17.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-react-jsx
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-react-jsx
 │  └─ licenseFile: node_modules\@babel\plugin-transform-react-jsx\LICENSE
 ├─ @babel/plugin-transform-react-pure-annotations@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-react-pure-annotations
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-react-pure-annotations
 │  └─ licenseFile: node_modules\@babel\plugin-transform-react-pure-annotations\LICENSE
 ├─ @babel/plugin-transform-regenerator@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-regenerator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-regenerator
 │  └─ licenseFile: node_modules\@babel\plugin-transform-regenerator\LICENSE
 ├─ @babel/plugin-transform-reserved-words@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-reserved-words
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-reserved-words
 │  └─ licenseFile: node_modules\@babel\plugin-transform-reserved-words\LICENSE
 ├─ @babel/plugin-transform-shorthand-properties@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-shorthand-properties
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-shorthand-properties
 │  └─ licenseFile: node_modules\@babel\plugin-transform-shorthand-properties\LICENSE
 ├─ @babel/plugin-transform-spread@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-spread
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-spread
 │  └─ licenseFile: node_modules\@babel\plugin-transform-spread\LICENSE
 ├─ @babel/plugin-transform-sticky-regex@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-sticky-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-sticky-regex
 │  └─ licenseFile: node_modules\@babel\plugin-transform-sticky-regex\LICENSE
 ├─ @babel/plugin-transform-template-literals@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-template-literals
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-template-literals
 │  └─ licenseFile: node_modules\@babel\plugin-transform-template-literals\LICENSE
 ├─ @babel/plugin-transform-typeof-symbol@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-typeof-symbol
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-typeof-symbol
 │  └─ licenseFile: node_modules\@babel\plugin-transform-typeof-symbol\LICENSE
 ├─ @babel/plugin-transform-typescript@7.16.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-typescript
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-typescript
 │  └─ licenseFile: node_modules\@babel\plugin-transform-typescript\LICENSE
 ├─ @babel/plugin-transform-unicode-escapes@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-unicode-escapes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-unicode-escapes
 │  └─ licenseFile: node_modules\@babel\plugin-transform-unicode-escapes\LICENSE
 ├─ @babel/plugin-transform-unicode-regex@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\plugin-transform-unicode-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\plugin-transform-unicode-regex
 │  └─ licenseFile: node_modules\@babel\plugin-transform-unicode-regex\LICENSE
 ├─ @babel/preset-env@7.16.11
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\preset-env
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\preset-env
 │  └─ licenseFile: node_modules\@babel\preset-env\LICENSE
 ├─ @babel/preset-modules@0.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/preset-modules
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\preset-modules
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\preset-modules
 │  └─ licenseFile: node_modules\@babel\preset-modules\LICENSE
 ├─ @babel/preset-react@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\preset-react
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\preset-react
 │  └─ licenseFile: node_modules\@babel\preset-react\LICENSE
 ├─ @babel/preset-typescript@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\preset-typescript
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\preset-typescript
 │  └─ licenseFile: node_modules\@babel\preset-typescript\LICENSE
-├─ @babel/register@7.17.0
+├─ @babel/register@7.17.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\register
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\register
 │  └─ licenseFile: node_modules\@babel\register\LICENSE
-├─ @babel/runtime@7.17.2
+├─ @babel/runtime@7.17.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\runtime
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\runtime
 │  └─ licenseFile: node_modules\@babel\runtime\LICENSE
 ├─ @babel/template@7.16.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\template
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\template
 │  └─ licenseFile: node_modules\@babel\template\LICENSE
 ├─ @babel/traverse@7.17.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\traverse
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\traverse
 │  └─ licenseFile: node_modules\@babel\traverse\LICENSE
 ├─ @babel/types@7.17.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel
 │  ├─ publisher: The Babel Team
 │  ├─ url: https://babel.dev/team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@babel\types
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@babel\types
 │  └─ licenseFile: node_modules\@babel\types\LICENSE
 ├─ @base2/pretty-print-object@1.0.1
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/Chris-Baker/pretty-print-object
 │  ├─ publisher: Chris Baker
-│  ├─ path: C:\dev\dnn-elements\node_modules\@base2\pretty-print-object
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@base2\pretty-print-object
 │  └─ licenseFile: node_modules\@base2\pretty-print-object\LICENSE
 ├─ @bcoe/v8-coverage@0.2.3
 │  ├─ licenses: MIT
@@ -799,14 +799,14 @@
 │  ├─ publisher: Charles Samborski
 │  ├─ email: demurgos@demurgos.net
 │  ├─ url: https://demurgos.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\@bcoe\v8-coverage
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@bcoe\v8-coverage
 │  └─ licenseFile: node_modules\@bcoe\v8-coverage\LICENSE.md
 ├─ @cnakazawa/watch@1.0.4
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/mikeal/watch
 │  ├─ publisher: Mikeal Rogers
 │  ├─ email: mikeal.rogers@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\@cnakazawa\watch
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@cnakazawa\watch
 │  └─ licenseFile: node_modules\@cnakazawa\watch\LICENSE
 ├─ @discoveryjs/json-ext@0.5.7
 │  ├─ licenses: MIT
@@ -814,208 +814,208 @@
 │  ├─ publisher: Roman Dvornov
 │  ├─ email: rdvornov@gmail.com
 │  ├─ url: https://github.com/lahmatiy
-│  ├─ path: C:\dev\dnn-elements\node_modules\@discoveryjs\json-ext
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@discoveryjs\json-ext
 │  └─ licenseFile: node_modules\@discoveryjs\json-ext\LICENSE
 ├─ @dnncommunity/dnn-elements@0.15.0-alpha.98
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/dnncommunity/dnn-elements
-│  ├─ path: C:\dev\dnn-elements
+│  ├─ path: D:\dnn-elements\dnn-elements
 │  └─ licenseFile: LICENSE
 ├─ @emotion/cache@10.0.29
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/cache
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\cache
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\cache
 │  └─ licenseFile: node_modules\@emotion\cache\LICENSE
 ├─ @emotion/core@10.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/core
 │  ├─ publisher: mitchellhamilton
 │  ├─ email: mitchell@mitchellhamilton.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\core
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\core
 │  └─ licenseFile: node_modules\@emotion\core\LICENSE
 ├─ @emotion/css@10.0.27
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/css
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\css
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\css
 │  └─ licenseFile: node_modules\@emotion\css\LICENSE
 ├─ @emotion/hash@0.8.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/hash
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\hash
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\hash
 │  └─ licenseFile: node_modules\@emotion\hash\LICENSE
 ├─ @emotion/is-prop-valid@0.8.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/is-prop-valid
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\is-prop-valid
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\is-prop-valid
 │  └─ licenseFile: node_modules\@emotion\is-prop-valid\LICENSE
 ├─ @emotion/memoize@0.7.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/memoize
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\memoize
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\memoize
 │  └─ licenseFile: node_modules\@emotion\memoize\LICENSE
 ├─ @emotion/serialize@0.11.16
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/serialize
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\serialize
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\serialize
 │  └─ licenseFile: node_modules\@emotion\serialize\LICENSE
 ├─ @emotion/sheet@0.9.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/sheet
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\sheet
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\sheet
 │  └─ licenseFile: node_modules\@emotion\sheet\LICENSE
 ├─ @emotion/styled-base@10.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/styled-base
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\styled-base
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\styled-base
 │  └─ licenseFile: node_modules\@emotion\styled-base\LICENSE
 ├─ @emotion/styled@10.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/styled
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\styled
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\styled
 │  └─ licenseFile: node_modules\@emotion\styled\LICENSE
 ├─ @emotion/stylis@0.8.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/stylis
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\stylis
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\stylis
 │  └─ licenseFile: node_modules\@emotion\stylis\LICENSE
 ├─ @emotion/unitless@0.7.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/unitless
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\unitless
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\unitless
 │  └─ licenseFile: node_modules\@emotion\unitless\LICENSE
 ├─ @emotion/utils@0.11.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/serialize
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\utils
 │  └─ licenseFile: node_modules\@emotion\utils\LICENSE
 ├─ @emotion/weak-memoize@0.2.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/weak-memoize
-│  ├─ path: C:\dev\dnn-elements\node_modules\@emotion\weak-memoize
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@emotion\weak-memoize
 │  └─ licenseFile: node_modules\@emotion\weak-memoize\LICENSE
 ├─ @eslint/eslintrc@0.4.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/eslint/eslintrc
 │  ├─ publisher: Nicholas C. Zakas
-│  ├─ path: C:\dev\dnn-elements\node_modules\@eslint\eslintrc
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@eslint\eslintrc
 │  └─ licenseFile: node_modules\@eslint\eslintrc\LICENSE
 ├─ @gar/promisify@1.1.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/wraithgar/gar-promisify
 │  ├─ publisher: Gar
 │  ├─ email: gar+npm@danger.computer
-│  ├─ path: C:\dev\dnn-elements\node_modules\@gar\promisify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@gar\promisify
 │  └─ licenseFile: node_modules\@gar\promisify\LICENSE.md
 ├─ @geometricpanda/storybook-addon-badges@0.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/geometricpanda/geometricpanda/tree/main/libs/storybook-addon-badges
 │  ├─ publisher: geometricpanda
-│  ├─ path: C:\dev\dnn-elements\node_modules\@geometricpanda\storybook-addon-badges
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@geometricpanda\storybook-addon-badges
 │  └─ licenseFile: node_modules\@geometricpanda\storybook-addon-badges\LICENCE.md
 ├─ @humanwhocodes/config-array@0.5.0
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/humanwhocodes/config-array
 │  ├─ publisher: Nicholas C. Zakas
-│  ├─ path: C:\dev\dnn-elements\node_modules\@humanwhocodes\config-array
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@humanwhocodes\config-array
 │  └─ licenseFile: node_modules\@humanwhocodes\config-array\LICENSE
 ├─ @humanwhocodes/object-schema@1.2.1
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/humanwhocodes/object-schema
 │  ├─ publisher: Nicholas C. Zakas
-│  ├─ path: C:\dev\dnn-elements\node_modules\@humanwhocodes\object-schema
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@humanwhocodes\object-schema
 │  └─ licenseFile: node_modules\@humanwhocodes\object-schema\LICENSE
 ├─ @hypnosphi/create-react-context@0.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/thejameskyle/create-react-context
 │  ├─ publisher: James Kyle
 │  ├─ email: me@thejameskyle.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\@hypnosphi\create-react-context
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@hypnosphi\create-react-context
 │  └─ licenseFile: node_modules\@hypnosphi\create-react-context\LICENSE
 ├─ @istanbuljs/load-nyc-config@1.1.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/istanbuljs/load-nyc-config
-│  ├─ path: C:\dev\dnn-elements\node_modules\@istanbuljs\load-nyc-config
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@istanbuljs\load-nyc-config
 │  └─ licenseFile: node_modules\@istanbuljs\load-nyc-config\LICENSE
 ├─ @istanbuljs/schema@0.1.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/istanbuljs/schema
 │  ├─ publisher: Corey Farrell
-│  ├─ path: C:\dev\dnn-elements\node_modules\@istanbuljs\schema
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@istanbuljs\schema
 │  └─ licenseFile: node_modules\@istanbuljs\schema\LICENSE
 ├─ @jest/console@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jest\console
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\console
 │  └─ licenseFile: node_modules\@jest\console\LICENSE
 ├─ @jest/core@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jest\core
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\core
 │  └─ licenseFile: node_modules\@jest\core\LICENSE
 ├─ @jest/environment@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jest\environment
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\environment
 │  └─ licenseFile: node_modules\@jest\environment\LICENSE
 ├─ @jest/fake-timers@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jest\fake-timers
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\fake-timers
 │  └─ licenseFile: node_modules\@jest\fake-timers\LICENSE
 ├─ @jest/globals@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jest\globals
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\globals
 │  └─ licenseFile: node_modules\@jest\globals\LICENSE
 ├─ @jest/reporters@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jest\reporters
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\reporters
 │  └─ licenseFile: node_modules\@jest\reporters\LICENSE
 ├─ @jest/source-map@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jest\source-map
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\source-map
 │  └─ licenseFile: node_modules\@jest\source-map\LICENSE
 ├─ @jest/test-result@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jest\test-result
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\test-result
 │  └─ licenseFile: node_modules\@jest\test-result\LICENSE
 ├─ @jest/test-sequencer@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jest\test-sequencer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\test-sequencer
 │  └─ licenseFile: node_modules\@jest\test-sequencer\LICENSE
-├─ @jest/transform@27.5.1
+├─ @jest/transform@26.6.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jest\transform
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\transform
 │  └─ licenseFile: node_modules\@jest\transform\LICENSE
 ├─ @jest/types@26.6.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jest\types
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\types
 │  └─ licenseFile: node_modules\@jest\types\LICENSE
 ├─ @jridgewell/resolve-uri@3.0.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jridgewell/resolve-uri
 │  ├─ publisher: Justin Ridgewell
 │  ├─ email: justin@ridgewell.name
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jridgewell\resolve-uri
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jridgewell\resolve-uri
 │  └─ licenseFile: node_modules\@jridgewell\resolve-uri\LICENSE
 ├─ @jridgewell/sourcemap-codec@1.4.11
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jridgewell/sourcemap-codec
 │  ├─ publisher: Rich Harris
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jridgewell\sourcemap-codec
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jridgewell\sourcemap-codec
 │  └─ licenseFile: node_modules\@jridgewell\sourcemap-codec\LICENSE
 ├─ @jridgewell/trace-mapping@0.3.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jridgewell/trace-mapping
 │  ├─ publisher: Justin Ridgewell
 │  ├─ email: justin@ridgewell.name
-│  ├─ path: C:\dev\dnn-elements\node_modules\@jridgewell\trace-mapping
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jridgewell\trace-mapping
 │  └─ licenseFile: node_modules\@jridgewell\trace-mapping\LICENSE
 ├─ @mdx-js/loader@1.6.22
 │  ├─ licenses: MIT
@@ -1023,7 +1023,7 @@
 │  ├─ publisher: John Otander
 │  ├─ email: johnotander@gmail.com
 │  ├─ url: http://johnotander.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\@mdx-js\loader
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@mdx-js\loader
 │  └─ licenseFile: node_modules\@mdx-js\loader\license
 ├─ @mdx-js/mdx@1.6.22
 │  ├─ licenses: MIT
@@ -1031,7 +1031,7 @@
 │  ├─ publisher: John Otander
 │  ├─ email: johnotander@gmail.com
 │  ├─ url: http://johnotander.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\@mdx-js\mdx
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@mdx-js\mdx
 │  └─ licenseFile: node_modules\@mdx-js\mdx\license
 ├─ @mdx-js/react@1.6.22
 │  ├─ licenses: MIT
@@ -1039,7 +1039,7 @@
 │  ├─ publisher: John Otander
 │  ├─ email: johnotander@gmail.com
 │  ├─ url: http://johnotander.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\@mdx-js\react
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@mdx-js\react
 │  └─ licenseFile: node_modules\@mdx-js\react\license
 ├─ @mdx-js/util@1.6.22
 │  ├─ licenses: MIT
@@ -1047,283 +1047,278 @@
 │  ├─ publisher: John Otander
 │  ├─ email: johnotander@gmail.com
 │  ├─ url: http://johnotander.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\@mdx-js\util
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@mdx-js\util
 │  └─ licenseFile: node_modules\@mdx-js\util\license
 ├─ @mrmlnc/readdir-enhanced@2.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/bigstickcarpet/readdir-enhanced
 │  ├─ publisher: James Messinger
 │  ├─ url: http://bigstickcarpet.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\@mrmlnc\readdir-enhanced
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@mrmlnc\readdir-enhanced
 │  └─ licenseFile: node_modules\@mrmlnc\readdir-enhanced\LICENSE
 ├─ @nodelib/fs.scandir@2.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir
-│  ├─ path: C:\dev\dnn-elements\node_modules\@nodelib\fs.scandir
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@nodelib\fs.scandir
 │  └─ licenseFile: node_modules\@nodelib\fs.scandir\LICENSE
-├─ @nodelib/fs.stat@2.0.5
+├─ @nodelib/fs.stat@1.1.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat
-│  ├─ path: C:\dev\dnn-elements\node_modules\@nodelib\fs.stat
-│  └─ licenseFile: node_modules\@nodelib\fs.stat\LICENSE
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@nodelib\fs.stat
+│  └─ licenseFile: node_modules\@nodelib\fs.stat\README.md
 ├─ @nodelib/fs.walk@1.2.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk
-│  ├─ path: C:\dev\dnn-elements\node_modules\@nodelib\fs.walk
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@nodelib\fs.walk
 │  └─ licenseFile: node_modules\@nodelib\fs.walk\LICENSE
 ├─ @npmcli/fs@1.1.1
 │  ├─ licenses: ISC
 │  ├─ publisher: GitHub Inc.
-│  ├─ path: C:\dev\dnn-elements\node_modules\@npmcli\fs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@npmcli\fs
 │  └─ licenseFile: node_modules\@npmcli\fs\LICENSE.md
 ├─ @npmcli/move-file@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/npm/move-file
-│  ├─ path: C:\dev\dnn-elements\node_modules\@npmcli\move-file
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@npmcli\move-file
 │  └─ licenseFile: node_modules\@npmcli\move-file\LICENSE.md
-├─ @popperjs/core@2.11.2
+├─ @popperjs/core@2.11.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/popperjs/popper-core
 │  ├─ publisher: Federico Zivolo
 │  ├─ email: federico.zivolo@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\@popperjs\core
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@popperjs\core
 │  └─ licenseFile: node_modules\@popperjs\core\LICENSE.md
 ├─ @reach/router@1.3.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/reach/router
 │  ├─ publisher: Ryan Florence
-│  ├─ path: C:\dev\dnn-elements\node_modules\@reach\router
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@reach\router
 │  └─ licenseFile: node_modules\@reach\router\LICENSE
 ├─ @sinonjs/commons@1.8.3
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/sinonjs/commons
-│  ├─ path: C:\dev\dnn-elements\node_modules\@sinonjs\commons
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@sinonjs\commons
 │  └─ licenseFile: node_modules\@sinonjs\commons\LICENSE
 ├─ @sinonjs/fake-timers@8.1.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/sinonjs/fake-timers
 │  ├─ publisher: Christian Johansen
-│  ├─ path: C:\dev\dnn-elements\node_modules\@sinonjs\fake-timers
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@sinonjs\fake-timers
 │  └─ licenseFile: node_modules\@sinonjs\fake-timers\LICENSE
-├─ @stencil/core@2.13.0
+├─ @stencil/core@2.14.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ionic-team/stencil
 │  ├─ publisher: Ionic Team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@stencil\core
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@stencil\core
 │  └─ licenseFile: node_modules\@stencil\core\LICENSE.md
 ├─ @stencil/eslint-plugin@0.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ionic-team/stencil-eslint
-│  ├─ path: C:\dev\dnn-elements\node_modules\@stencil\eslint-plugin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@stencil\eslint-plugin
 │  └─ licenseFile: node_modules\@stencil\eslint-plugin\LICENSE.md
 ├─ @stencil/sass@1.5.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ionic-team/stencil-sass
 │  ├─ publisher: Ionic Team
-│  ├─ path: C:\dev\dnn-elements\node_modules\@stencil\sass
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@stencil\sass
 │  └─ licenseFile: node_modules\@stencil\sass\LICENSE
 ├─ @storybook/addon-a11y@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-a11y
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-a11y
 │  └─ licenseFile: node_modules\@storybook\addon-a11y\LICENSE
 ├─ @storybook/addon-actions@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-actions
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-actions
 │  └─ licenseFile: node_modules\@storybook\addon-actions\LICENSE
 ├─ @storybook/addon-backgrounds@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
 │  ├─ publisher: jbaxleyiii
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-backgrounds
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-backgrounds
 │  └─ licenseFile: node_modules\@storybook\addon-backgrounds\LICENSE
 ├─ @storybook/addon-controls@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-controls
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-controls
 │  └─ licenseFile: node_modules\@storybook\addon-controls\LICENSE
 ├─ @storybook/addon-docs@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-docs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-docs
 │  └─ licenseFile: node_modules\@storybook\addon-docs\LICENSE
 ├─ @storybook/addon-essentials@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-essentials
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-essentials
 │  └─ licenseFile: node_modules\@storybook\addon-essentials\LICENSE
 ├─ @storybook/addon-links@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-links
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-links
 │  └─ licenseFile: node_modules\@storybook\addon-links\LICENSE
 ├─ @storybook/addon-measure@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
 │  ├─ publisher: winkerVSbecks
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-measure
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-measure
 │  └─ licenseFile: node_modules\@storybook\addon-measure\LICENSE
 ├─ @storybook/addon-notes@5.3.21
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-notes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-notes
 │  └─ licenseFile: node_modules\@storybook\addon-notes\LICENSE
 ├─ @storybook/addon-outline@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
 │  ├─ publisher: winkerVSbecks
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-outline
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-outline
 │  └─ licenseFile: node_modules\@storybook\addon-outline\LICENSE
 ├─ @storybook/addon-toolbars@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-toolbars
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-toolbars
 │  └─ licenseFile: node_modules\@storybook\addon-toolbars\LICENSE
 ├─ @storybook/addon-viewport@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addon-viewport
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addon-viewport
 │  └─ licenseFile: node_modules\@storybook\addon-viewport\LICENSE
 ├─ @storybook/addons@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\addons
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\addons
 │  └─ licenseFile: node_modules\@storybook\addons\LICENSE
 ├─ @storybook/api@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\api
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\api
 │  └─ licenseFile: node_modules\@storybook\api\LICENSE
 ├─ @storybook/builder-webpack4@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\builder-webpack4
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\builder-webpack4
 │  └─ licenseFile: node_modules\@storybook\builder-webpack4\LICENSE
 ├─ @storybook/channel-postmessage@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\channel-postmessage
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\channel-postmessage
 │  └─ licenseFile: node_modules\@storybook\channel-postmessage\LICENSE
 ├─ @storybook/channel-websocket@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\channel-websocket
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\channel-websocket
 │  └─ licenseFile: node_modules\@storybook\channel-websocket\LICENSE
 ├─ @storybook/channels@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\channels
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\channels
 │  └─ licenseFile: node_modules\@storybook\channels\LICENSE
 ├─ @storybook/client-api@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\client-api
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\client-api
 │  └─ licenseFile: node_modules\@storybook\client-api\LICENSE
 ├─ @storybook/client-logger@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\client-logger
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\client-logger
 │  └─ licenseFile: node_modules\@storybook\client-logger\LICENSE
 ├─ @storybook/components@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\components
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\components
 │  └─ licenseFile: node_modules\@storybook\components\LICENSE
 ├─ @storybook/core-client@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\core-client
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\core-client
 │  └─ licenseFile: node_modules\@storybook\core-client\LICENSE
 ├─ @storybook/core-common@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\core-common
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\core-common
 │  └─ licenseFile: node_modules\@storybook\core-common\LICENSE
 ├─ @storybook/core-events@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\core-events
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\core-events
 │  └─ licenseFile: node_modules\@storybook\core-events\LICENSE
 ├─ @storybook/core-server@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\core-server
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\core-server
 │  └─ licenseFile: node_modules\@storybook\core-server\LICENSE
 ├─ @storybook/core@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\core
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\core
 │  └─ licenseFile: node_modules\@storybook\core\LICENSE
 ├─ @storybook/csf-tools@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\csf-tools
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\csf-tools
 │  └─ licenseFile: node_modules\@storybook\csf-tools\LICENSE
 ├─ @storybook/csf@0.0.2--canary.87bc651.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ComponentDriven/csf
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\csf
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\csf
 │  └─ licenseFile: node_modules\@storybook\csf\README.md
 ├─ @storybook/html@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\html
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\html
 │  └─ licenseFile: node_modules\@storybook\html\LICENSE
 ├─ @storybook/manager-webpack4@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\manager-webpack4
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\manager-webpack4
 │  └─ licenseFile: node_modules\@storybook\manager-webpack4\LICENSE
 ├─ @storybook/node-logger@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\node-logger
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\node-logger
 │  └─ licenseFile: node_modules\@storybook\node-logger\LICENSE
 ├─ @storybook/postinstall@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\postinstall
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\postinstall
 │  └─ licenseFile: node_modules\@storybook\postinstall\LICENSE
 ├─ @storybook/preview-web@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\preview-web
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\preview-web
 │  └─ licenseFile: node_modules\@storybook\preview-web\LICENSE
 ├─ @storybook/router@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\router
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\router
 │  └─ licenseFile: node_modules\@storybook\router\LICENSE
-├─ @storybook/semver@7.3.2
-│  ├─ licenses: ISC
-│  ├─ repository: https://github.com/storybookjs/browser-semver
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\semver
-│  └─ licenseFile: node_modules\@storybook\semver\LICENSE
 ├─ @storybook/source-loader@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\source-loader
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\source-loader
 │  └─ licenseFile: node_modules\@storybook\source-loader\LICENSE
 ├─ @storybook/store@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\store
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\store
 │  └─ licenseFile: node_modules\@storybook\store\LICENSE
 ├─ @storybook/theming@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\theming
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\theming
 │  └─ licenseFile: node_modules\@storybook\theming\LICENSE
 ├─ @storybook/ui@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\ui
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\ui
 │  └─ licenseFile: node_modules\@storybook\ui\LICENSE
 ├─ @storybook/web-components@6.4.19
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybookjs/storybook
-│  ├─ path: C:\dev\dnn-elements\node_modules\@storybook\web-components
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@storybook\web-components
 │  └─ licenseFile: node_modules\@storybook\web-components\LICENSE
 ├─ @tootallnate/once@1.1.2
 │  ├─ licenses: MIT
@@ -1331,373 +1326,378 @@
 │  ├─ publisher: Nathan Rajlich
 │  ├─ email: nathan@tootallnate.net
 │  ├─ url: http://n8.io/
-│  └─ path: C:\dev\dnn-elements\node_modules\@tootallnate\once
-├─ @types/babel__core@7.1.16
+│  └─ path: D:\dnn-elements\dnn-elements\node_modules\@tootallnate\once
+├─ @types/babel__core@7.1.18
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\babel__core
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\babel__core
 │  └─ licenseFile: node_modules\@types\babel__core\LICENSE
-├─ @types/babel__generator@7.6.3
+├─ @types/babel__generator@7.6.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\babel__generator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\babel__generator
 │  └─ licenseFile: node_modules\@types\babel__generator\LICENSE
 ├─ @types/babel__template@7.4.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\babel__template
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\babel__template
 │  └─ licenseFile: node_modules\@types\babel__template\LICENSE
 ├─ @types/babel__traverse@7.14.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\babel__traverse
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\babel__traverse
 │  └─ licenseFile: node_modules\@types\babel__traverse\LICENSE
 ├─ @types/color-convert@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\color-convert
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\color-convert
 │  └─ licenseFile: node_modules\@types\color-convert\LICENSE
 ├─ @types/color-name@1.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\color-name
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\color-name
 │  └─ licenseFile: node_modules\@types\color-name\LICENSE
 ├─ @types/glob@7.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\glob
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\glob
 │  └─ licenseFile: node_modules\@types\glob\LICENSE
 ├─ @types/graceful-fs@4.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\graceful-fs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\graceful-fs
 │  └─ licenseFile: node_modules\@types\graceful-fs\LICENSE
 ├─ @types/hast@2.3.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\hast
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\hast
 │  └─ licenseFile: node_modules\@types\hast\LICENSE
 ├─ @types/html-minifier-terser@5.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\html-minifier-terser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\html-minifier-terser
 │  └─ licenseFile: node_modules\@types\html-minifier-terser\LICENSE
 ├─ @types/is-function@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\is-function
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\is-function
 │  └─ licenseFile: node_modules\@types\is-function\LICENSE
-├─ @types/istanbul-lib-coverage@2.0.3
+├─ @types/istanbul-lib-coverage@2.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\istanbul-lib-coverage
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\istanbul-lib-coverage
 │  └─ licenseFile: node_modules\@types\istanbul-lib-coverage\LICENSE
 ├─ @types/istanbul-lib-report@3.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\istanbul-lib-report
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\istanbul-lib-report
 │  └─ licenseFile: node_modules\@types\istanbul-lib-report\LICENSE
 ├─ @types/istanbul-reports@3.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\istanbul-reports
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\istanbul-reports
 │  └─ licenseFile: node_modules\@types\istanbul-reports\LICENSE
 ├─ @types/jest@27.4.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\jest
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\jest
 │  └─ licenseFile: node_modules\@types\jest\LICENSE
-├─ @types/json-schema@7.0.9
+├─ @types/json-schema@7.0.10
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\json-schema
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\json-schema
 │  └─ licenseFile: node_modules\@types\json-schema\LICENSE
 ├─ @types/mdast@3.0.10
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\mdast
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\mdast
 │  └─ licenseFile: node_modules\@types\mdast\LICENSE
 ├─ @types/minimatch@3.0.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\minimatch
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\minimatch
 │  └─ licenseFile: node_modules\@types\minimatch\LICENSE
 ├─ @types/node-fetch@2.6.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\node-fetch
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\node-fetch
 │  └─ licenseFile: node_modules\@types\node-fetch\LICENSE
-├─ @types/node@14.11.7
+├─ @types/node@14.18.12
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\node
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\node
 │  └─ licenseFile: node_modules\@types\node\LICENSE
 ├─ @types/normalize-package-data@2.4.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\normalize-package-data
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\normalize-package-data
 │  └─ licenseFile: node_modules\@types\normalize-package-data\LICENSE
 ├─ @types/npmlog@4.1.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\npmlog
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\npmlog
 │  └─ licenseFile: node_modules\@types\npmlog\LICENSE
 ├─ @types/overlayscrollbars@1.12.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\overlayscrollbars
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\overlayscrollbars
 │  └─ licenseFile: node_modules\@types\overlayscrollbars\LICENSE
 ├─ @types/parse-json@4.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\parse-json
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\parse-json
 │  └─ licenseFile: node_modules\@types\parse-json\LICENSE
 ├─ @types/parse5@5.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\parse5
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\parse5
 │  └─ licenseFile: node_modules\@types\parse5\LICENSE
-├─ @types/prettier@2.4.1
+├─ @types/prettier@2.4.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\prettier
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\prettier
 │  └─ licenseFile: node_modules\@types\prettier\LICENSE
 ├─ @types/pretty-hrtime@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\pretty-hrtime
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\pretty-hrtime
 │  └─ licenseFile: node_modules\@types\pretty-hrtime\LICENSE
 ├─ @types/prop-types@15.7.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\prop-types
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\prop-types
 │  └─ licenseFile: node_modules\@types\prop-types\LICENSE
 ├─ @types/puppeteer@5.4.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\puppeteer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\puppeteer
 │  └─ licenseFile: node_modules\@types\puppeteer\LICENSE
 ├─ @types/qs@6.9.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\qs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\qs
 │  └─ licenseFile: node_modules\@types\qs\LICENSE
 ├─ @types/reach__router@1.3.10
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\reach__router
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\reach__router
 │  └─ licenseFile: node_modules\@types\reach__router\LICENSE
 ├─ @types/react-syntax-highlighter@11.0.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\react-syntax-highlighter
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\react-syntax-highlighter
 │  └─ licenseFile: node_modules\@types\react-syntax-highlighter\LICENSE
 ├─ @types/react-textarea-autosize@4.3.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\react-textarea-autosize
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\react-textarea-autosize
 │  └─ licenseFile: node_modules\@types\react-textarea-autosize\LICENSE
 ├─ @types/react@17.0.40
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\react
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\react
 │  └─ licenseFile: node_modules\@types\react\LICENSE
 ├─ @types/scheduler@0.16.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\scheduler
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\scheduler
 │  └─ licenseFile: node_modules\@types\scheduler\LICENSE
 ├─ @types/source-list-map@0.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\source-list-map
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\source-list-map
 │  └─ licenseFile: node_modules\@types\source-list-map\LICENSE
 ├─ @types/stack-utils@2.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\stack-utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\stack-utils
 │  └─ licenseFile: node_modules\@types\stack-utils\LICENSE
 ├─ @types/tapable@1.0.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\tapable
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\tapable
 │  └─ licenseFile: node_modules\@types\tapable\LICENSE
 ├─ @types/trusted-types@2.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\trusted-types
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\trusted-types
 │  └─ licenseFile: node_modules\@types\trusted-types\LICENSE
 ├─ @types/uglify-js@3.13.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\uglify-js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\uglify-js
 │  └─ licenseFile: node_modules\@types\uglify-js\LICENSE
 ├─ @types/unist@2.0.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\unist
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\unist
 │  └─ licenseFile: node_modules\@types\unist\LICENSE
 ├─ @types/webpack-env@1.16.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\webpack-env
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\webpack-env
 │  └─ licenseFile: node_modules\@types\webpack-env\LICENSE
 ├─ @types/webpack-sources@3.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\webpack-sources
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\webpack-sources
 │  └─ licenseFile: node_modules\@types\webpack-sources\LICENSE
 ├─ @types/webpack@4.41.32
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\webpack
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\webpack
 │  └─ licenseFile: node_modules\@types\webpack\LICENSE
-├─ @types/yargs-parser@15.0.0
+├─ @types/yargs-parser@21.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\yargs-parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\yargs-parser
 │  └─ licenseFile: node_modules\@types\yargs-parser\LICENSE
-├─ @types/yargs@16.0.4
+├─ @types/yargs@15.0.14
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\yargs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\yargs
 │  └─ licenseFile: node_modules\@types\yargs\LICENSE
 ├─ @types/yauzl@2.9.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: C:\dev\dnn-elements\node_modules\@types\yauzl
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\yauzl
 │  └─ licenseFile: node_modules\@types\yauzl\LICENSE
 ├─ @typescript-eslint/eslint-plugin@4.33.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
-│  ├─ path: C:\dev\dnn-elements\node_modules\@typescript-eslint\eslint-plugin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@typescript-eslint\eslint-plugin
 │  └─ licenseFile: node_modules\@typescript-eslint\eslint-plugin\LICENSE
+├─ @typescript-eslint/experimental-utils@4.33.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@typescript-eslint\experimental-utils
+│  └─ licenseFile: node_modules\@typescript-eslint\experimental-utils\LICENSE
 ├─ @typescript-eslint/parser@4.33.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
-│  ├─ path: C:\dev\dnn-elements\node_modules\@typescript-eslint\parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@typescript-eslint\parser
 │  └─ licenseFile: node_modules\@typescript-eslint\parser\LICENSE
 ├─ @typescript-eslint/scope-manager@4.33.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
-│  ├─ path: C:\dev\dnn-elements\node_modules\@typescript-eslint\scope-manager
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@typescript-eslint\scope-manager
 │  └─ licenseFile: node_modules\@typescript-eslint\scope-manager\LICENSE
 ├─ @typescript-eslint/types@4.33.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
-│  ├─ path: C:\dev\dnn-elements\node_modules\@typescript-eslint\types
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@typescript-eslint\types
 │  └─ licenseFile: node_modules\@typescript-eslint\types\LICENSE
 ├─ @typescript-eslint/typescript-estree@4.33.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
-│  ├─ path: C:\dev\dnn-elements\node_modules\@typescript-eslint\typescript-estree
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@typescript-eslint\typescript-estree
 │  └─ licenseFile: node_modules\@typescript-eslint\typescript-estree\LICENSE
 ├─ @typescript-eslint/visitor-keys@4.33.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
-│  ├─ path: C:\dev\dnn-elements\node_modules\@typescript-eslint\visitor-keys
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@typescript-eslint\visitor-keys
 │  └─ licenseFile: node_modules\@typescript-eslint\visitor-keys\LICENSE
 ├─ @webassemblyjs/ast@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\ast
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\ast
 │  └─ licenseFile: node_modules\@webassemblyjs\ast\LICENSE
 ├─ @webassemblyjs/floating-point-hex-parser@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Mauro Bringolf
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\floating-point-hex-parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\floating-point-hex-parser
 │  └─ licenseFile: node_modules\@webassemblyjs\floating-point-hex-parser\LICENSE
 ├─ @webassemblyjs/helper-api-error@1.9.0
 │  ├─ licenses: MIT
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\helper-api-error
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\helper-api-error
 │  └─ licenseFile: node_modules\@webassemblyjs\helper-api-error\LICENSE
 ├─ @webassemblyjs/helper-buffer@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\helper-buffer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\helper-buffer
 │  └─ licenseFile: node_modules\@webassemblyjs\helper-buffer\LICENSE
 ├─ @webassemblyjs/helper-code-frame@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\helper-code-frame
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\helper-code-frame
 │  └─ licenseFile: node_modules\@webassemblyjs\helper-code-frame\LICENSE
 ├─ @webassemblyjs/helper-fsm@1.9.0
 │  ├─ licenses: ISC
 │  ├─ publisher: Mauro Bringolf
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\helper-fsm
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\helper-fsm
 │  └─ licenseFile: node_modules\@webassemblyjs\helper-fsm\LICENSE
 ├─ @webassemblyjs/helper-module-context@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\helper-module-context
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\helper-module-context
 │  └─ licenseFile: node_modules\@webassemblyjs\helper-module-context\LICENSE
 ├─ @webassemblyjs/helper-wasm-bytecode@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\helper-wasm-bytecode
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\helper-wasm-bytecode
 │  └─ licenseFile: node_modules\@webassemblyjs\helper-wasm-bytecode\LICENSE
 ├─ @webassemblyjs/helper-wasm-section@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\helper-wasm-section
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\helper-wasm-section
 │  └─ licenseFile: node_modules\@webassemblyjs\helper-wasm-section\LICENSE
 ├─ @webassemblyjs/ieee754@1.9.0
 │  ├─ licenses: MIT
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\ieee754
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\ieee754
 │  └─ licenseFile: node_modules\@webassemblyjs\ieee754\LICENSE
 ├─ @webassemblyjs/leb128@1.9.0
 │  ├─ licenses: MIT
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\leb128
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\leb128
 │  └─ licenseFile: node_modules\@webassemblyjs\leb128\LICENSE.txt
 ├─ @webassemblyjs/utf8@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\utf8
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\utf8
 │  └─ licenseFile: node_modules\@webassemblyjs\utf8\LICENSE
 ├─ @webassemblyjs/wasm-edit@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\wasm-edit
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\wasm-edit
 │  └─ licenseFile: node_modules\@webassemblyjs\wasm-edit\LICENSE
 ├─ @webassemblyjs/wasm-gen@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\wasm-gen
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\wasm-gen
 │  └─ licenseFile: node_modules\@webassemblyjs\wasm-gen\LICENSE
 ├─ @webassemblyjs/wasm-opt@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\wasm-opt
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\wasm-opt
 │  └─ licenseFile: node_modules\@webassemblyjs\wasm-opt\LICENSE
 ├─ @webassemblyjs/wasm-parser@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\wasm-parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\wasm-parser
 │  └─ licenseFile: node_modules\@webassemblyjs\wasm-parser\LICENSE
 ├─ @webassemblyjs/wast-parser@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\wast-parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\wast-parser
 │  └─ licenseFile: node_modules\@webassemblyjs\wast-parser\LICENSE
 ├─ @webassemblyjs/wast-printer@1.9.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/webassemblyjs
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\@webassemblyjs\wast-printer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@webassemblyjs\wast-printer
 │  └─ licenseFile: node_modules\@webassemblyjs\wast-printer\LICENSE
 ├─ @xtuc/ieee754@1.2.0
 │  ├─ licenses: BSD-3-Clause
@@ -1705,61 +1705,61 @@
 │  ├─ publisher: Feross Aboukhadijeh
 │  ├─ email: feross@feross.org
 │  ├─ url: http://feross.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\@xtuc\ieee754
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@xtuc\ieee754
 │  └─ licenseFile: node_modules\@xtuc\ieee754\LICENSE
 ├─ @xtuc/long@4.2.2
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/dcodeIO/long.js
 │  ├─ publisher: Daniel Wirtz
 │  ├─ email: dcode@dcode.io
-│  ├─ path: C:\dev\dnn-elements\node_modules\@xtuc\long
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@xtuc\long
 │  └─ licenseFile: node_modules\@xtuc\long\LICENSE
 ├─ abab@2.0.5
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/jsdom/abab
 │  ├─ publisher: Jeff Carpenter
 │  ├─ email: gcarpenterv@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\abab
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\abab
 │  └─ licenseFile: node_modules\abab\LICENSE.md
 ├─ abbrev@1.1.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/abbrev-js
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\abbrev
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\abbrev
 │  └─ licenseFile: node_modules\abbrev\LICENSE
 ├─ accepts@1.3.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/accepts
-│  ├─ path: C:\dev\dnn-elements\node_modules\accepts
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\accepts
 │  └─ licenseFile: node_modules\accepts\LICENSE
 ├─ acorn-globals@6.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ForbesLindesay/acorn-globals
 │  ├─ publisher: ForbesLindesay
-│  ├─ path: C:\dev\dnn-elements\node_modules\acorn-globals
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\acorn-globals
 │  └─ licenseFile: node_modules\acorn-globals\LICENSE
 ├─ acorn-jsx@5.3.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/acornjs/acorn-jsx
-│  ├─ path: C:\dev\dnn-elements\node_modules\acorn-jsx
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\acorn-jsx
 │  └─ licenseFile: node_modules\acorn-jsx\LICENSE
 ├─ acorn-walk@7.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/acornjs/acorn
-│  ├─ path: C:\dev\dnn-elements\node_modules\acorn-walk
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\acorn-walk
 │  └─ licenseFile: node_modules\acorn-walk\LICENSE
-├─ acorn@8.5.0
+├─ acorn@6.4.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/acornjs/acorn
-│  ├─ path: C:\dev\dnn-elements\node_modules\acorn
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\acorn
 │  └─ licenseFile: node_modules\acorn\LICENSE
 ├─ address@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/node-modules/address
 │  ├─ publisher: fengmk2
 │  ├─ email: fengmk2@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\address
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\address
 │  └─ licenseFile: node_modules\address\LICENSE.txt
 ├─ agent-base@6.0.2
 │  ├─ licenses: MIT
@@ -1767,7 +1767,7 @@
 │  ├─ publisher: Nathan Rajlich
 │  ├─ email: nathan@tootallnate.net
 │  ├─ url: http://n8.io/
-│  ├─ path: C:\dev\dnn-elements\node_modules\agent-base
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\agent-base
 │  └─ licenseFile: node_modules\agent-base\README.md
 ├─ aggregate-error@3.1.0
 │  ├─ licenses: MIT
@@ -1775,44 +1775,44 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\aggregate-error
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\aggregate-error
 │  └─ licenseFile: node_modules\aggregate-error\license
 ├─ airbnb-js-shims@2.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/airbnb/js-shims
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\airbnb-js-shims
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\airbnb-js-shims
 │  └─ licenseFile: node_modules\airbnb-js-shims\LICENSE
 ├─ ajv-errors@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/epoberezkin/ajv-errors
-│  ├─ path: C:\dev\dnn-elements\node_modules\ajv-errors
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ajv-errors
 │  └─ licenseFile: node_modules\ajv-errors\LICENSE
 ├─ ajv-keywords@3.5.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/epoberezkin/ajv-keywords
 │  ├─ publisher: Evgeny Poberezkin
-│  ├─ path: C:\dev\dnn-elements\node_modules\ajv-keywords
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ajv-keywords
 │  └─ licenseFile: node_modules\ajv-keywords\LICENSE
 ├─ ajv@6.12.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ajv-validator/ajv
 │  ├─ publisher: Evgeny Poberezkin
-│  ├─ path: C:\dev\dnn-elements\node_modules\ajv
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ajv
 │  └─ licenseFile: node_modules\ajv\LICENSE
 ├─ ansi-align@3.0.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/nexdrew/ansi-align
 │  ├─ publisher: nexdrew
-│  ├─ path: C:\dev\dnn-elements\node_modules\ansi-align
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ansi-align
 │  └─ licenseFile: node_modules\ansi-align\LICENSE
-├─ ansi-colors@4.1.1
+├─ ansi-colors@3.2.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/doowb/ansi-colors
 │  ├─ publisher: Brian Woodward
 │  ├─ url: https://github.com/doowb
-│  ├─ path: C:\dev\dnn-elements\node_modules\ansi-colors
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ansi-colors
 │  └─ licenseFile: node_modules\ansi-colors\LICENSE
 ├─ ansi-escapes@4.3.2
 │  ├─ licenses: MIT
@@ -1820,13 +1820,13 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\ansi-escapes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ansi-escapes
 │  └─ licenseFile: node_modules\ansi-escapes\license
 ├─ ansi-html-community@0.0.8
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/mahdyar/ansi-html-community
 │  ├─ publisher: mahdyar
-│  ├─ path: C:\dev\dnn-elements\node_modules\ansi-html-community
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ansi-html-community
 │  └─ licenseFile: node_modules\ansi-html-community\LICENSE
 ├─ ansi-regex@5.0.1
 │  ├─ licenses: MIT
@@ -1834,15 +1834,15 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\ansi-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ansi-regex
 │  └─ licenseFile: node_modules\ansi-regex\license
-├─ ansi-styles@4.3.0
+├─ ansi-styles@3.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/chalk/ansi-styles
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\ansi-styles
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ansi-styles
 │  └─ licenseFile: node_modules\ansi-styles\license
 ├─ ansi-to-html@0.6.15
 │  ├─ licenses: MIT
@@ -1850,60 +1850,60 @@
 │  ├─ publisher: Rob Burns
 │  ├─ email: rburns@paiges.net
 │  ├─ url: http://rburns.paiges.net/
-│  ├─ path: C:\dev\dnn-elements\node_modules\ansi-to-html
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ansi-to-html
 │  └─ licenseFile: node_modules\ansi-to-html\LICENSE-MIT.txt
 ├─ anymatch@3.1.2
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/micromatch/anymatch
 │  ├─ publisher: Elan Shanker
 │  ├─ url: https://github.com/es128
-│  ├─ path: C:\dev\dnn-elements\node_modules\anymatch
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\anymatch
 │  └─ licenseFile: node_modules\anymatch\LICENSE
 ├─ app-root-dir@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/philidem/node-app-root-dir
 │  ├─ publisher: Phillip Gates-Idem
 │  ├─ email: phillip.idem@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\app-root-dir
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\app-root-dir
 │  └─ licenseFile: node_modules\app-root-dir\LICENSE
 ├─ aproba@2.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/iarna/aproba
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\aproba
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\aproba
 │  └─ licenseFile: node_modules\aproba\LICENSE
 ├─ are-we-there-yet@2.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/npm/are-we-there-yet
 │  ├─ publisher: GitHub Inc.
-│  ├─ path: C:\dev\dnn-elements\node_modules\are-we-there-yet
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\are-we-there-yet
 │  └─ licenseFile: node_modules\are-we-there-yet\LICENSE.md
 ├─ argparse@1.0.10
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/nodeca/argparse
-│  ├─ path: C:\dev\dnn-elements\node_modules\argparse
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\argparse
 │  └─ licenseFile: node_modules\argparse\LICENSE
 ├─ arr-diff@4.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/arr-diff
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\arr-diff
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\arr-diff
 │  └─ licenseFile: node_modules\arr-diff\LICENSE
 ├─ arr-flatten@1.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/arr-flatten
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\arr-flatten
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\arr-flatten
 │  └─ licenseFile: node_modules\arr-flatten\LICENSE
 ├─ arr-union@3.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/arr-union
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\arr-union
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\arr-union
 │  └─ licenseFile: node_modules\arr-union\LICENSE
 ├─ array-find-index@1.0.2
 │  ├─ licenses: MIT
@@ -1911,7 +1911,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\array-find-index
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\array-find-index
 │  └─ licenseFile: node_modules\array-find-index\license
 ├─ array-flatten@1.1.1
 │  ├─ licenses: MIT
@@ -1919,7 +1919,7 @@
 │  ├─ publisher: Blake Embrey
 │  ├─ email: hello@blakeembrey.com
 │  ├─ url: http://blakeembrey.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\array-flatten
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\array-flatten
 │  └─ licenseFile: node_modules\array-flatten\LICENSE
 ├─ array-includes@3.1.4
 │  ├─ licenses: MIT
@@ -1927,15 +1927,15 @@
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
 │  ├─ url: http://ljharb.codes
-│  ├─ path: C:\dev\dnn-elements\node_modules\array-includes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\array-includes
 │  └─ licenseFile: node_modules\array-includes\LICENSE
-├─ array-union@2.1.0
+├─ array-union@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/array-union
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\array-union
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\array-union
 │  └─ licenseFile: node_modules\array-union\license
 ├─ array-uniq@1.0.3
 │  ├─ licenses: MIT
@@ -1943,14 +1943,14 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\array-uniq
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\array-uniq
 │  └─ licenseFile: node_modules\array-uniq\license
 ├─ array-unique@0.3.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/array-unique
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\array-unique
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\array-unique
 │  └─ licenseFile: node_modules\array-unique\LICENSE
 ├─ array.prototype.flat@1.2.5
 │  ├─ licenses: MIT
@@ -1958,7 +1958,7 @@
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
 │  ├─ url: http://ljharb.codes
-│  ├─ path: C:\dev\dnn-elements\node_modules\array.prototype.flat
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\array.prototype.flat
 │  └─ licenseFile: node_modules\array.prototype.flat\LICENSE
 ├─ array.prototype.flatmap@1.2.5
 │  ├─ licenses: MIT
@@ -1966,14 +1966,14 @@
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
 │  ├─ url: http://ljharb.codes
-│  ├─ path: C:\dev\dnn-elements\node_modules\array.prototype.flatmap
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\array.prototype.flatmap
 │  └─ licenseFile: node_modules\array.prototype.flatmap\LICENSE
 ├─ array.prototype.map@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/Array.prototype.map
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\array.prototype.map
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\array.prototype.map
 │  └─ licenseFile: node_modules\array.prototype.map\LICENSE
 ├─ arrify@2.0.1
 │  ├─ licenses: MIT
@@ -1981,30 +1981,30 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\arrify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\arrify
 │  └─ licenseFile: node_modules\arrify\license
 ├─ asap@2.0.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/kriskowal/asap
-│  ├─ path: C:\dev\dnn-elements\node_modules\asap
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\asap
 │  └─ licenseFile: node_modules\asap\LICENSE.md
 ├─ asn1.js@5.4.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/indutny/asn1.js
 │  ├─ publisher: Fedor Indutny
-│  ├─ path: C:\dev\dnn-elements\node_modules\asn1.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\asn1.js
 │  └─ licenseFile: node_modules\asn1.js\LICENSE
 ├─ assert@1.5.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/browserify/commonjs-assert
-│  ├─ path: C:\dev\dnn-elements\node_modules\assert
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\assert
 │  └─ licenseFile: node_modules\assert\LICENSE
 ├─ assign-symbols@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/assign-symbols
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\assign-symbols
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\assign-symbols
 │  └─ licenseFile: node_modules\assign-symbols\LICENSE
 ├─ astral-regex@2.0.0
 │  ├─ licenses: MIT
@@ -2012,28 +2012,28 @@
 │  ├─ publisher: Kevin Mårtensson
 │  ├─ email: kevinmartensson@gmail.com
 │  ├─ url: github.com/kevva
-│  ├─ path: C:\dev\dnn-elements\node_modules\astral-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\astral-regex
 │  └─ licenseFile: node_modules\astral-regex\license
 ├─ async-each@1.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/paulmillr/async-each
 │  ├─ publisher: Paul Miller
 │  ├─ url: https://paulmillr.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\async-each
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\async-each
 │  └─ licenseFile: node_modules\async-each\README.md
 ├─ asynckit@0.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/alexindigo/asynckit
 │  ├─ publisher: Alex Indigo
 │  ├─ email: iam@alexindigo.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\asynckit
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\asynckit
 │  └─ licenseFile: node_modules\asynckit\LICENSE
 ├─ at-least-node@1.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/RyanZim/at-least-node
 │  ├─ publisher: Ryan Zimmerman
 │  ├─ email: opensrc@ryanzim.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\at-least-node
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\at-least-node
 │  └─ licenseFile: node_modules\at-least-node\LICENSE
 ├─ atob@2.1.2
 │  ├─ licenses: (MIT OR Apache-2.0)
@@ -2041,31 +2041,31 @@
 │  ├─ publisher: AJ ONeal
 │  ├─ email: coolaj86@gmail.com
 │  ├─ url: https://coolaj86.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\atob
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\atob
 │  └─ licenseFile: node_modules\atob\LICENSE
 ├─ autoprefixer@9.8.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/postcss/autoprefixer
 │  ├─ publisher: Andrey Sitnik
 │  ├─ email: andrey@sitnik.ru
-│  ├─ path: C:\dev\dnn-elements\node_modules\autoprefixer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\autoprefixer
 │  └─ licenseFile: node_modules\autoprefixer\LICENSE
 ├─ axe-core@4.4.1
 │  ├─ licenses: MPL-2.0
 │  ├─ repository: https://github.com/dequelabs/axe-core
-│  ├─ path: C:\dev\dnn-elements\node_modules\axe-core
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\axe-core
 │  └─ licenseFile: node_modules\axe-core\LICENSE
 ├─ babel-jest@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-jest
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-jest
 │  └─ licenseFile: node_modules\babel-jest\LICENSE
 ├─ babel-loader@8.2.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel-loader
 │  ├─ publisher: Luis Couto
 │  ├─ email: hello@luiscouto.pt
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-loader
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-loader
 │  └─ licenseFile: node_modules\babel-loader\LICENSE
 ├─ babel-plugin-apply-mdx-type-prop@1.6.22
 │  ├─ licenses: MIT
@@ -2073,26 +2073,26 @@
 │  ├─ publisher: John Otander
 │  ├─ email: johnotander@gmail.com
 │  ├─ url: http://johnotander.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-apply-mdx-type-prop
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-apply-mdx-type-prop
 │  └─ licenseFile: node_modules\babel-plugin-apply-mdx-type-prop\license
 ├─ babel-plugin-bundled-import-meta@0.3.2
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/cfware/babel-plugin-bundled-import-meta
 │  ├─ publisher: Corey Farrell
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-bundled-import-meta
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-bundled-import-meta
 │  └─ licenseFile: node_modules\babel-plugin-bundled-import-meta\LICENSE
 ├─ babel-plugin-dynamic-import-node@2.3.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/airbnb/babel-plugin-dynamic-import-node
 │  ├─ publisher: Jordan Gensler
 │  ├─ email: jordan.gensler@airbnb.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-dynamic-import-node
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-dynamic-import-node
 │  └─ licenseFile: node_modules\babel-plugin-dynamic-import-node\LICENSE
 ├─ babel-plugin-emotion@10.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/babel-plugin-emotion
 │  ├─ publisher: Kye Hohenberger
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-emotion
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-emotion
 │  └─ licenseFile: node_modules\babel-plugin-emotion\LICENSE
 ├─ babel-plugin-extract-import-names@1.6.22
 │  ├─ licenses: MIT
@@ -2100,18 +2100,18 @@
 │  ├─ publisher: John Otander
 │  ├─ email: johnotander@gmail.com
 │  ├─ url: http://johnotander.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-extract-import-names
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-extract-import-names
 │  └─ licenseFile: node_modules\babel-plugin-extract-import-names\license
 ├─ babel-plugin-istanbul@6.1.1
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/istanbuljs/babel-plugin-istanbul
 │  ├─ publisher: Thai Pangsakulyanont @dtinth
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-istanbul
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-istanbul
 │  └─ licenseFile: node_modules\babel-plugin-istanbul\LICENSE
 ├─ babel-plugin-jest-hoist@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-jest-hoist
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-jest-hoist
 │  └─ licenseFile: node_modules\babel-plugin-jest-hoist\LICENSE
 ├─ babel-plugin-macros@2.8.0
 │  ├─ licenses: MIT
@@ -2119,39 +2119,39 @@
 │  ├─ publisher: Kent C. Dodds
 │  ├─ email: kent@doddsfamily.us
 │  ├─ url: http://kentcdodds.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-macros
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-macros
 │  └─ licenseFile: node_modules\babel-plugin-macros\LICENSE
 ├─ babel-plugin-polyfill-corejs2@0.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel-polyfills
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-polyfill-corejs2
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-polyfill-corejs2
 │  └─ licenseFile: node_modules\babel-plugin-polyfill-corejs2\LICENSE
-├─ babel-plugin-polyfill-corejs3@0.5.2
+├─ babel-plugin-polyfill-corejs3@0.1.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel-polyfills
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-polyfill-corejs3
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-polyfill-corejs3
 │  └─ licenseFile: node_modules\babel-plugin-polyfill-corejs3\LICENSE
 ├─ babel-plugin-polyfill-regenerator@0.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel-polyfills
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-polyfill-regenerator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-polyfill-regenerator
 │  └─ licenseFile: node_modules\babel-plugin-polyfill-regenerator\LICENSE
 ├─ babel-plugin-syntax-jsx@6.18.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-plugin-syntax-jsx
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-syntax-jsx
 │  └─ licenseFile: node_modules\babel-plugin-syntax-jsx\README.md
 ├─ babel-preset-current-node-syntax@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/nicolo-ribaudo/babel-preset-current-node-syntax
 │  ├─ publisher: Nicolò Ribaudo
 │  ├─ url: https://github.com/nicolo-ribaudo
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-preset-current-node-syntax
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-preset-current-node-syntax
 │  └─ licenseFile: node_modules\babel-preset-current-node-syntax\LICENSE
 ├─ babel-preset-jest@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\babel-preset-jest
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-preset-jest
 │  └─ licenseFile: node_modules\babel-preset-jest\LICENSE
 ├─ bail@1.0.5
 │  ├─ licenses: MIT
@@ -2159,49 +2159,49 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\bail
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\bail
 │  └─ licenseFile: node_modules\bail\license
-├─ balanced-match@1.0.0
+├─ balanced-match@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/juliangruber/balanced-match
 │  ├─ publisher: Julian Gruber
 │  ├─ email: mail@juliangruber.com
 │  ├─ url: http://juliangruber.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\balanced-match
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\balanced-match
 │  └─ licenseFile: node_modules\balanced-match\LICENSE.md
 ├─ base64-js@1.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/beatgammit/base64-js
 │  ├─ publisher: T. Jameson Little
 │  ├─ email: t.jameson.little@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\base64-js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\base64-js
 │  └─ licenseFile: node_modules\base64-js\LICENSE
 ├─ base@0.11.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/node-base/base
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\base
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\base
 │  └─ licenseFile: node_modules\base\LICENSE
 ├─ batch-processor@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/wnr/batch-processor
 │  ├─ publisher: Lucas Wiener
-│  ├─ path: C:\dev\dnn-elements\node_modules\batch-processor
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\batch-processor
 │  └─ licenseFile: node_modules\batch-processor\LICENSE
 ├─ better-opn@2.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ExiaSR/better-opn
 │  ├─ publisher: Michael Lin
 │  ├─ email: linzichunzf@hotmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\better-opn
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\better-opn
 │  └─ licenseFile: node_modules\better-opn\LICENSE
 ├─ big.js@5.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/MikeMcl/big.js
 │  ├─ publisher: Michael Mclaughlin
 │  ├─ email: M8ch88l@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\big.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\big.js
 │  └─ licenseFile: node_modules\big.js\LICENCE
 ├─ binary-extensions@2.2.0
 │  ├─ licenses: MIT
@@ -2209,12 +2209,12 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\binary-extensions
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\binary-extensions
 │  └─ licenseFile: node_modules\binary-extensions\license
 ├─ bl@4.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/rvagg/bl
-│  ├─ path: C:\dev\dnn-elements\node_modules\bl
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\bl
 │  └─ licenseFile: node_modules\bl\LICENSE.md
 ├─ bluebird@3.7.2
 │  ├─ licenses: MIT
@@ -2222,26 +2222,26 @@
 │  ├─ publisher: Petka Antonov
 │  ├─ email: petka_antonov@hotmail.com
 │  ├─ url: http://github.com/petkaantonov/
-│  ├─ path: C:\dev\dnn-elements\node_modules\bluebird
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\bluebird
 │  └─ licenseFile: node_modules\bluebird\LICENSE
 ├─ bn.js@5.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/indutny/bn.js
 │  ├─ publisher: Fedor Indutny
 │  ├─ email: fedor@indutny.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\bn.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\bn.js
 │  └─ licenseFile: node_modules\bn.js\LICENSE
 ├─ body-parser@1.19.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/expressjs/body-parser
-│  ├─ path: C:\dev\dnn-elements\node_modules\body-parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\body-parser
 │  └─ licenseFile: node_modules\body-parser\LICENSE
 ├─ boolbase@1.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/fb55/boolbase
 │  ├─ publisher: Felix Boehm
 │  ├─ email: me@feedic.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\boolbase
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\boolbase
 │  └─ licenseFile: node_modules\boolbase\README.md
 ├─ boxen@5.1.2
 │  ├─ licenses: MIT
@@ -2249,7 +2249,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\boxen
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\boxen
 │  └─ licenseFile: node_modules\boxen\license
 ├─ brace-expansion@1.1.11
 │  ├─ licenses: MIT
@@ -2257,70 +2257,70 @@
 │  ├─ publisher: Julian Gruber
 │  ├─ email: mail@juliangruber.com
 │  ├─ url: http://juliangruber.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\brace-expansion
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\brace-expansion
 │  └─ licenseFile: node_modules\brace-expansion\LICENSE
 ├─ braces@3.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/micromatch/braces
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\braces
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\braces
 │  └─ licenseFile: node_modules\braces\LICENSE
 ├─ brorand@1.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/indutny/brorand
 │  ├─ publisher: Fedor Indutny
 │  ├─ email: fedor@indutny.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\brorand
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\brorand
 │  └─ licenseFile: node_modules\brorand\README.md
 ├─ browser-process-hrtime@1.0.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/kumavis/browser-process-hrtime
 │  ├─ publisher: kumavis
-│  ├─ path: C:\dev\dnn-elements\node_modules\browser-process-hrtime
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\browser-process-hrtime
 │  └─ licenseFile: node_modules\browser-process-hrtime\LICENSE
 ├─ browserify-aes@1.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/browserify-aes
-│  ├─ path: C:\dev\dnn-elements\node_modules\browserify-aes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\browserify-aes
 │  └─ licenseFile: node_modules\browserify-aes\LICENSE
 ├─ browserify-cipher@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/browserify-cipher
 │  ├─ publisher: Calvin Metcalf
 │  ├─ email: calvin.metcalf@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\browserify-cipher
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\browserify-cipher
 │  └─ licenseFile: node_modules\browserify-cipher\LICENSE
 ├─ browserify-des@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/browserify-des
 │  ├─ publisher: Calvin Metcalf
 │  ├─ email: calvin.metcalf@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\browserify-des
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\browserify-des
 │  └─ licenseFile: node_modules\browserify-des\license
 ├─ browserify-rsa@4.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/browserify-rsa
-│  ├─ path: C:\dev\dnn-elements\node_modules\browserify-rsa
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\browserify-rsa
 │  └─ licenseFile: node_modules\browserify-rsa\LICENSE
 ├─ browserify-sign@4.2.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/crypto-browserify/browserify-sign
-│  ├─ path: C:\dev\dnn-elements\node_modules\browserify-sign
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\browserify-sign
 │  └─ licenseFile: node_modules\browserify-sign\LICENSE
 ├─ browserify-zlib@0.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/devongovett/browserify-zlib
 │  ├─ publisher: Devon Govett
 │  ├─ email: devongovett@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\browserify-zlib
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\browserify-zlib
 │  └─ licenseFile: node_modules\browserify-zlib\LICENSE
-├─ browserslist@4.20.0
+├─ browserslist@4.20.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/browserslist/browserslist
 │  ├─ publisher: Andrey Sitnik
 │  ├─ email: andrey@sitnik.ru
-│  ├─ path: C:\dev\dnn-elements\node_modules\browserslist
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\browserslist
 │  └─ licenseFile: node_modules\browserslist\LICENSE
 ├─ bser@2.1.1
 │  ├─ licenses: Apache-2.0
@@ -2328,33 +2328,33 @@
 │  ├─ publisher: Wez Furlong
 │  ├─ email: wez@fb.com
 │  ├─ url: http://wezfurlong.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\bser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\bser
 │  └─ licenseFile: node_modules\bser\README.md
 ├─ buffer-crc32@0.2.13
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/brianloveswords/buffer-crc32
 │  ├─ publisher: Brian J. Brennan
 │  ├─ email: brianloveswords@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\buffer-crc32
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\buffer-crc32
 │  └─ licenseFile: node_modules\buffer-crc32\LICENSE
 ├─ buffer-from@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/LinusU/buffer-from
-│  ├─ path: C:\dev\dnn-elements\node_modules\buffer-from
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\buffer-from
 │  └─ licenseFile: node_modules\buffer-from\LICENSE
 ├─ buffer-xor@1.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/buffer-xor
 │  ├─ publisher: Daniel Cousens
-│  ├─ path: C:\dev\dnn-elements\node_modules\buffer-xor
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\buffer-xor
 │  └─ licenseFile: node_modules\buffer-xor\LICENSE
-├─ buffer@5.7.1
+├─ buffer@4.9.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/feross/buffer
 │  ├─ publisher: Feross Aboukhadijeh
 │  ├─ email: feross@feross.org
-│  ├─ url: https://feross.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\buffer
+│  ├─ url: http://feross.org
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\buffer
 │  └─ licenseFile: node_modules\buffer\LICENSE
 ├─ builtin-status-codes@3.0.0
 │  ├─ licenses: MIT
@@ -2362,34 +2362,36 @@
 │  ├─ publisher: Ben Drucker
 │  ├─ email: bvdrucker@gmail.com
 │  ├─ url: bendrucker.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\builtin-status-codes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\builtin-status-codes
 │  └─ licenseFile: node_modules\builtin-status-codes\license
-├─ bytes@3.0.0
+├─ bytes@3.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/visionmedia/bytes.js
 │  ├─ publisher: TJ Holowaychuk
 │  ├─ email: tj@vision-media.ca
 │  ├─ url: http://tjholowaychuk.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\bytes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\bytes
 │  └─ licenseFile: node_modules\bytes\LICENSE
-├─ cacache@15.3.0
+├─ cacache@12.0.4
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/npm/cacache
-│  ├─ path: C:\dev\dnn-elements\node_modules\cacache
+│  ├─ publisher: Kat Marchán
+│  ├─ email: kzm@sykosomatic.org
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cacache
 │  └─ licenseFile: node_modules\cacache\LICENSE.md
 ├─ cache-base@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/cache-base
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\cache-base
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cache-base
 │  └─ licenseFile: node_modules\cache-base\LICENSE
 ├─ call-bind@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/call-bind
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\call-bind
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\call-bind
 │  └─ licenseFile: node_modules\call-bind\LICENSE
 ├─ call-me-maybe@1.0.1
 │  ├─ licenses: MIT
@@ -2397,7 +2399,7 @@
 │  ├─ publisher: Eric McCarthy
 │  ├─ email: eric@limulus.net
 │  ├─ url: http://www.limulus.net/
-│  ├─ path: C:\dev\dnn-elements\node_modules\call-me-maybe
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\call-me-maybe
 │  └─ licenseFile: node_modules\call-me-maybe\LICENSE
 ├─ callsites@3.1.0
 │  ├─ licenses: MIT
@@ -2405,7 +2407,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\callsites
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\callsites
 │  └─ licenseFile: node_modules\callsites\license
 ├─ camel-case@4.1.2
 │  ├─ licenses: MIT
@@ -2413,7 +2415,7 @@
 │  ├─ publisher: Blake Embrey
 │  ├─ email: hello@blakeembrey.com
 │  ├─ url: http://blakeembrey.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\camel-case
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\camel-case
 │  └─ licenseFile: node_modules\camel-case\LICENSE
 ├─ camelcase-css@2.0.1
 │  ├─ licenses: MIT
@@ -2421,7 +2423,7 @@
 │  ├─ publisher: Steven Vachon
 │  ├─ email: contact@svachon.com
 │  ├─ url: https://www.svachon.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\camelcase-css
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\camelcase-css
 │  └─ licenseFile: node_modules\camelcase-css\license
 ├─ camelcase@5.3.1
 │  ├─ licenses: MIT
@@ -2429,34 +2431,34 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\camelcase
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\camelcase
 │  └─ licenseFile: node_modules\camelcase\license
 ├─ can-use-dom@0.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/akiran/can-use-dom
 │  ├─ publisher: Kiran Abburi
-│  ├─ path: C:\dev\dnn-elements\node_modules\can-use-dom
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\can-use-dom
 │  └─ licenseFile: node_modules\can-use-dom\LICENSE
-├─ caniuse-lite@1.0.30001314
+├─ caniuse-lite@1.0.30001317
 │  ├─ licenses: CC-BY-4.0
 │  ├─ repository: https://github.com/browserslist/caniuse-lite
 │  ├─ publisher: Ben Briggs
 │  ├─ email: beneb.info@gmail.com
 │  ├─ url: http://beneb.info
-│  ├─ path: C:\dev\dnn-elements\node_modules\caniuse-lite
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\caniuse-lite
 │  └─ licenseFile: node_modules\caniuse-lite\LICENSE
 ├─ capture-exit@2.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/stefanpenner/capture-exit
 │  ├─ publisher: Stefan Penner
 │  ├─ email: stefan.penner@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\capture-exit
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\capture-exit
 │  └─ licenseFile: node_modules\capture-exit\README.md
 ├─ case-sensitive-paths-webpack-plugin@2.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Urthen/case-sensitive-paths-webpack-plugin
 │  ├─ publisher: Michael Pratt
-│  ├─ path: C:\dev\dnn-elements\node_modules\case-sensitive-paths-webpack-plugin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\case-sensitive-paths-webpack-plugin
 │  └─ licenseFile: node_modules\case-sensitive-paths-webpack-plugin\LICENSE
 ├─ ccount@1.1.0
 │  ├─ licenses: MIT
@@ -2464,19 +2466,19 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\ccount
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ccount
 │  └─ licenseFile: node_modules\ccount\license
-├─ chalk@4.1.2
+├─ chalk@2.4.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/chalk/chalk
-│  ├─ path: C:\dev\dnn-elements\node_modules\chalk
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\chalk
 │  └─ licenseFile: node_modules\chalk\license
 ├─ char-regex@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Richienb/char-regex
 │  ├─ publisher: Richie Bendall
 │  ├─ email: richiebendall@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\char-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\char-regex
 │  └─ licenseFile: node_modules\char-regex\LICENSE
 ├─ character-entities-legacy@1.1.4
 │  ├─ licenses: MIT
@@ -2484,7 +2486,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\character-entities-legacy
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\character-entities-legacy
 │  └─ licenseFile: node_modules\character-entities-legacy\license
 ├─ character-entities@1.2.4
 │  ├─ licenses: MIT
@@ -2492,7 +2494,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\character-entities
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\character-entities
 │  └─ licenseFile: node_modules\character-entities\license
 ├─ character-reference-invalid@1.1.4
 │  ├─ licenses: MIT
@@ -2500,20 +2502,20 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\character-reference-invalid
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\character-reference-invalid
 │  └─ licenseFile: node_modules\character-reference-invalid\license
 ├─ charcodes@0.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/xtuc/charcodes
 │  ├─ publisher: Sven Sauleau
-│  ├─ path: C:\dev\dnn-elements\node_modules\charcodes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\charcodes
 │  └─ licenseFile: node_modules\charcodes\README.md
 ├─ chokidar@3.5.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/paulmillr/chokidar
 │  ├─ publisher: Paul Miller
 │  ├─ url: https://paulmillr.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\chokidar
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\chokidar
 │  └─ licenseFile: node_modules\chokidar\LICENSE
 ├─ chownr@1.1.4
 │  ├─ licenses: ISC
@@ -2521,41 +2523,41 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\chownr
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\chownr
 │  └─ licenseFile: node_modules\chownr\LICENSE
 ├─ chrome-trace-event@1.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/samccone/chrome-trace-event
 │  ├─ publisher: Trent Mick, Sam Saccone
-│  ├─ path: C:\dev\dnn-elements\node_modules\chrome-trace-event
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\chrome-trace-event
 │  └─ licenseFile: node_modules\chrome-trace-event\LICENSE.txt
-├─ ci-info@3.3.0
+├─ ci-info@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/watson/ci-info
 │  ├─ publisher: Thomas Watson Steen
 │  ├─ email: w@tson.dk
 │  ├─ url: https://twitter.com/wa7son
-│  ├─ path: C:\dev\dnn-elements\node_modules\ci-info
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ci-info
 │  └─ licenseFile: node_modules\ci-info\LICENSE
 ├─ cipher-base@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/cipher-base
 │  ├─ publisher: Calvin Metcalf
 │  ├─ email: calvin.metcalf@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\cipher-base
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cipher-base
 │  └─ licenseFile: node_modules\cipher-base\LICENSE
 ├─ cjs-module-lexer@1.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/guybedford/cjs-module-lexer
 │  ├─ publisher: Guy Bedford
-│  ├─ path: C:\dev\dnn-elements\node_modules\cjs-module-lexer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cjs-module-lexer
 │  └─ licenseFile: node_modules\cjs-module-lexer\LICENSE
 ├─ class-utils@0.3.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/class-utils
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\class-utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\class-utils
 │  └─ licenseFile: node_modules\class-utils\LICENSE
 ├─ clean-css@4.2.4
 │  ├─ licenses: MIT
@@ -2563,7 +2565,7 @@
 │  ├─ publisher: Jakub Pawlowicz
 │  ├─ email: contact@jakubpawlowicz.com
 │  ├─ url: http://twitter.com/jakubpawlowicz
-│  ├─ path: C:\dev\dnn-elements\node_modules\clean-css
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\clean-css
 │  └─ licenseFile: node_modules\clean-css\LICENSE
 ├─ clean-stack@2.2.0
 │  ├─ licenses: MIT
@@ -2571,7 +2573,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\clean-stack
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\clean-stack
 │  └─ licenseFile: node_modules\clean-stack\license
 ├─ cli-boxes@2.2.1
 │  ├─ licenses: MIT
@@ -2579,32 +2581,32 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\cli-boxes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cli-boxes
 │  └─ licenseFile: node_modules\cli-boxes\license
 ├─ cli-table3@0.6.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/cli-table/cli-table3
 │  ├─ publisher: James Talmage
-│  ├─ path: C:\dev\dnn-elements\node_modules\cli-table3
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cli-table3
 │  └─ licenseFile: node_modules\cli-table3\LICENSE
 ├─ clipboard@2.0.10
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zenorocha/clipboard.js
-│  ├─ path: C:\dev\dnn-elements\node_modules\clipboard
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\clipboard
 │  └─ licenseFile: node_modules\clipboard\LICENSE
 ├─ cliui@7.0.4
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/yargs/cliui
 │  ├─ publisher: Ben Coe
 │  ├─ email: ben@npmjs.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\cliui
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cliui
 │  └─ licenseFile: node_modules\cliui\LICENSE.txt
 ├─ clone-deep@4.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/clone-deep
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\clone-deep
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\clone-deep
 │  └─ licenseFile: node_modules\clone-deep\LICENSE
 ├─ clsx@1.1.1
 │  ├─ licenses: MIT
@@ -2612,12 +2614,12 @@
 │  ├─ publisher: Luke Edwards
 │  ├─ email: luke.edwards05@gmail.com
 │  ├─ url: https://lukeed.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\clsx
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\clsx
 │  └─ licenseFile: node_modules\clsx\license
 ├─ co@4.6.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/tj/co
-│  ├─ path: C:\dev\dnn-elements\node_modules\co
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\co
 │  └─ licenseFile: node_modules\co\LICENSE
 ├─ collapse-white-space@1.0.6
 │  ├─ licenses: MIT
@@ -2625,33 +2627,33 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\collapse-white-space
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\collapse-white-space
 │  └─ licenseFile: node_modules\collapse-white-space\license
 ├─ collect-v8-coverage@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/SimenB/collect-v8-coverage
-│  ├─ path: C:\dev\dnn-elements\node_modules\collect-v8-coverage
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\collect-v8-coverage
 │  └─ licenseFile: node_modules\collect-v8-coverage\LICENSE
 ├─ collection-visit@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/collection-visit
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\collection-visit
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\collection-visit
 │  └─ licenseFile: node_modules\collection-visit\LICENSE
-├─ color-convert@2.0.1
+├─ color-convert@1.9.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Qix-/color-convert
 │  ├─ publisher: Heather Arthur
 │  ├─ email: fayearthur@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\color-convert
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\color-convert
 │  └─ licenseFile: node_modules\color-convert\LICENSE
-├─ color-name@1.1.4
+├─ color-name@1.1.3
 │  ├─ licenses: MIT
-│  ├─ repository: https://github.com/colorjs/color-name
+│  ├─ repository: https://github.com/dfcreative/color-name
 │  ├─ publisher: DY
 │  ├─ email: dfcreative@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\color-name
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\color-name
 │  └─ licenseFile: node_modules\color-name\LICENSE
 ├─ color-support@1.1.3
 │  ├─ licenses: ISC
@@ -2659,13 +2661,13 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\color-support
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\color-support
 │  └─ licenseFile: node_modules\color-support\LICENSE
 ├─ colors@1.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Marak/colors.js
 │  ├─ publisher: Marak Squires
-│  ├─ path: C:\dev\dnn-elements\node_modules\colors
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\colors
 │  └─ licenseFile: node_modules\colors\LICENSE
 ├─ combined-stream@1.0.8
 │  ├─ licenses: MIT
@@ -2673,7 +2675,7 @@
 │  ├─ publisher: Felix Geisendörfer
 │  ├─ email: felix@debuggable.com
 │  ├─ url: http://debuggable.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\combined-stream
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\combined-stream
 │  └─ licenseFile: node_modules\combined-stream\License
 ├─ comma-separated-tokens@1.0.8
 │  ├─ licenses: MIT
@@ -2681,14 +2683,14 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\comma-separated-tokens
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\comma-separated-tokens
 │  └─ licenseFile: node_modules\comma-separated-tokens\license
-├─ commander@6.2.1
+├─ commander@2.20.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/tj/commander.js
 │  ├─ publisher: TJ Holowaychuk
 │  ├─ email: tj@vision-media.ca
-│  ├─ path: C:\dev\dnn-elements\node_modules\commander
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\commander
 │  └─ licenseFile: node_modules\commander\LICENSE
 ├─ commondir@1.0.1
 │  ├─ licenses: MIT
@@ -2696,28 +2698,28 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\commondir
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\commondir
 │  └─ licenseFile: node_modules\commondir\LICENSE
 ├─ component-emitter@1.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/component/emitter
-│  ├─ path: C:\dev\dnn-elements\node_modules\component-emitter
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\component-emitter
 │  └─ licenseFile: node_modules\component-emitter\LICENSE
 ├─ compressible@2.0.18
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/compressible
-│  ├─ path: C:\dev\dnn-elements\node_modules\compressible
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\compressible
 │  └─ licenseFile: node_modules\compressible\LICENSE
 ├─ compression@1.7.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/expressjs/compression
-│  ├─ path: C:\dev\dnn-elements\node_modules\compression
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\compression
 │  └─ licenseFile: node_modules\compression\LICENSE
 ├─ compute-scroll-into-view@1.0.17
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/stipsan/compute-scroll-into-view
 │  ├─ publisher: Cody Olsen
-│  ├─ path: C:\dev\dnn-elements\node_modules\compute-scroll-into-view
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\compute-scroll-into-view
 │  └─ licenseFile: node_modules\compute-scroll-into-view\LICENSE
 ├─ concat-map@0.0.1
 │  ├─ licenses: MIT
@@ -2725,21 +2727,21 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\concat-map
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\concat-map
 │  └─ licenseFile: node_modules\concat-map\LICENSE
 ├─ concat-stream@1.6.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/maxogden/concat-stream
 │  ├─ publisher: Max Ogden
 │  ├─ email: max@maxogden.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\concat-stream
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\concat-stream
 │  └─ licenseFile: node_modules\concat-stream\LICENSE
 ├─ console-browserify@1.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/browserify/console-browserify
 │  ├─ publisher: Raynos
 │  ├─ email: raynos2@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\console-browserify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\console-browserify
 │  └─ licenseFile: node_modules\console-browserify\LICENCE
 ├─ console-control-strings@1.1.0
 │  ├─ licenses: ISC
@@ -2747,7 +2749,7 @@
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
 │  ├─ url: http://re-becca.org/
-│  ├─ path: C:\dev\dnn-elements\node_modules\console-control-strings
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\console-control-strings
 │  └─ licenseFile: node_modules\console-control-strings\LICENSE
 ├─ constants-browserify@1.0.0
 │  ├─ licenses: MIT
@@ -2755,21 +2757,21 @@
 │  ├─ publisher: Julian Gruber
 │  ├─ email: julian@juliangruber.com
 │  ├─ url: http://juliangruber.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\constants-browserify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\constants-browserify
 │  └─ licenseFile: node_modules\constants-browserify\README.md
 ├─ content-disposition@0.5.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/content-disposition
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\content-disposition
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\content-disposition
 │  └─ licenseFile: node_modules\content-disposition\LICENSE
 ├─ content-type@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/content-type
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\content-type
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\content-type
 │  └─ licenseFile: node_modules\content-type\LICENSE
 ├─ convert-source-map@1.8.0
 │  ├─ licenses: MIT
@@ -2777,21 +2779,21 @@
 │  ├─ publisher: Thorsten Lorenz
 │  ├─ email: thlorenz@gmx.de
 │  ├─ url: http://thlorenz.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\convert-source-map
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\convert-source-map
 │  └─ licenseFile: node_modules\convert-source-map\LICENSE
 ├─ cookie-signature@1.0.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/visionmedia/node-cookie-signature
 │  ├─ publisher: TJ Holowaychuk
 │  ├─ email: tj@learnboost.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\cookie-signature
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cookie-signature
 │  └─ licenseFile: node_modules\cookie-signature\Readme.md
 ├─ cookie@0.4.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/cookie
 │  ├─ publisher: Roman Shtylman
 │  ├─ email: shtylman@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\cookie
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cookie
 │  └─ licenseFile: node_modules\cookie\LICENSE
 ├─ copy-concurrently@1.0.5
 │  ├─ licenses: ISC
@@ -2799,36 +2801,36 @@
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
 │  ├─ url: http://re-becca.org/
-│  ├─ path: C:\dev\dnn-elements\node_modules\copy-concurrently
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\copy-concurrently
 │  └─ licenseFile: node_modules\copy-concurrently\LICENSE
 ├─ copy-descriptor@0.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/copy-descriptor
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\copy-descriptor
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\copy-descriptor
 │  └─ licenseFile: node_modules\copy-descriptor\LICENSE
 ├─ copy-to-clipboard@3.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sudodoki/copy-to-clipboard
 │  ├─ publisher: sudodoki
 │  ├─ email: smd.deluzion@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\copy-to-clipboard
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\copy-to-clipboard
 │  └─ licenseFile: node_modules\copy-to-clipboard\LICENSE
 ├─ core-js-compat@3.21.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zloirock/core-js
-│  ├─ path: C:\dev\dnn-elements\node_modules\core-js-compat
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\core-js-compat
 │  └─ licenseFile: node_modules\core-js-compat\LICENSE
 ├─ core-js-pure@3.21.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zloirock/core-js
-│  ├─ path: C:\dev\dnn-elements\node_modules\core-js-pure
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\core-js-pure
 │  └─ licenseFile: node_modules\core-js-pure\LICENSE
 ├─ core-js@3.21.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zloirock/core-js
-│  ├─ path: C:\dev\dnn-elements\node_modules\core-js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\core-js
 │  └─ licenseFile: node_modules\core-js\LICENSE
 ├─ core-util-is@1.0.3
 │  ├─ licenses: MIT
@@ -2836,14 +2838,14 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\core-util-is
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\core-util-is
 │  └─ licenseFile: node_modules\core-util-is\LICENSE
 ├─ cosmiconfig@6.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/davidtheclark/cosmiconfig
 │  ├─ publisher: David Clark
 │  ├─ email: david.dave.clark@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\cosmiconfig
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cosmiconfig
 │  └─ licenseFile: node_modules\cosmiconfig\LICENSE
 ├─ cp-file@7.0.0
 │  ├─ licenses: MIT
@@ -2851,7 +2853,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\cp-file
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cp-file
 │  └─ licenseFile: node_modules\cp-file\license
 ├─ cpy@8.1.2
 │  ├─ licenses: MIT
@@ -2859,44 +2861,44 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\cpy
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cpy
 │  └─ licenseFile: node_modules\cpy\license
 ├─ create-ecdh@4.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/createECDH
 │  ├─ publisher: Calvin Metcalf
-│  ├─ path: C:\dev\dnn-elements\node_modules\create-ecdh
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\create-ecdh
 │  └─ licenseFile: node_modules\create-ecdh\LICENSE
 ├─ create-hash@1.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/createHash
-│  ├─ path: C:\dev\dnn-elements\node_modules\create-hash
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\create-hash
 │  └─ licenseFile: node_modules\create-hash\LICENSE
 ├─ create-hmac@1.1.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/createHmac
-│  ├─ path: C:\dev\dnn-elements\node_modules\create-hmac
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\create-hmac
 │  └─ licenseFile: node_modules\create-hmac\LICENSE
 ├─ create-react-context@0.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/thejameskyle/create-react-context
 │  ├─ publisher: James Kyle
 │  ├─ email: me@thejameskyle.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\create-react-context
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\create-react-context
 │  └─ licenseFile: node_modules\create-react-context\LICENSE
 ├─ cross-fetch@3.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lquixada/cross-fetch
 │  ├─ publisher: Leonardo Quixada
 │  ├─ email: lquixada@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\cross-fetch
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cross-fetch
 │  └─ licenseFile: node_modules\cross-fetch\LICENSE
-├─ cross-spawn@7.0.3
+├─ cross-spawn@6.0.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/moxystudio/node-cross-spawn
 │  ├─ publisher: André Cruz
 │  ├─ email: andre@moxy.studio
-│  ├─ path: C:\dev\dnn-elements\node_modules\cross-spawn
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cross-spawn
 │  └─ licenseFile: node_modules\cross-spawn\LICENSE
 ├─ crypto-browserify@3.12.0
 │  ├─ licenses: MIT
@@ -2904,20 +2906,20 @@
 │  ├─ publisher: Dominic Tarr
 │  ├─ email: dominic.tarr@gmail.com
 │  ├─ url: dominictarr.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\crypto-browserify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\crypto-browserify
 │  └─ licenseFile: node_modules\crypto-browserify\LICENSE
 ├─ css-loader@3.6.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack-contrib/css-loader
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\css-loader
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\css-loader
 │  └─ licenseFile: node_modules\css-loader\LICENSE
 ├─ css-select@4.2.1
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/fb55/css-select
 │  ├─ publisher: Felix Boehm
 │  ├─ email: me@feedic.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\css-select
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\css-select
 │  └─ licenseFile: node_modules\css-select\LICENSE
 ├─ css-what@5.1.0
 │  ├─ licenses: BSD-2-Clause
@@ -2925,40 +2927,40 @@
 │  ├─ publisher: Felix Böhm
 │  ├─ email: me@feedic.com
 │  ├─ url: http://feedic.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\css-what
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\css-what
 │  └─ licenseFile: node_modules\css-what\LICENSE
 ├─ cssesc@3.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/cssesc
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\cssesc
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cssesc
 │  └─ licenseFile: node_modules\cssesc\LICENSE-MIT.txt
 ├─ cssom@0.4.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/NV/CSSOM
 │  ├─ publisher: Nikita Vasilyev
 │  ├─ email: me@elv1s.ru
-│  ├─ path: C:\dev\dnn-elements\node_modules\cssom
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cssom
 │  └─ licenseFile: node_modules\cssom\LICENSE.txt
 ├─ cssstyle@2.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jsdom/cssstyle
-│  ├─ path: C:\dev\dnn-elements\node_modules\cssstyle
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cssstyle
 │  └─ licenseFile: node_modules\cssstyle\LICENSE
 ├─ csstype@2.6.20
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/frenic/csstype
 │  ├─ publisher: Fredrik Nicol
 │  ├─ email: fredrik.nicol@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\csstype
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\csstype
 │  └─ licenseFile: node_modules\csstype\LICENSE
 ├─ cyclist@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/cyclist
 │  ├─ publisher: Mathias Buus Madsen
 │  ├─ email: mathiasbuus@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\cyclist
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cyclist
 │  └─ licenseFile: node_modules\cyclist\LICENSE
 ├─ data-urls@2.0.0
 │  ├─ licenses: MIT
@@ -2966,28 +2968,28 @@
 │  ├─ publisher: Domenic Denicola
 │  ├─ email: d@domenic.me
 │  ├─ url: https://domenic.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\data-urls
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\data-urls
 │  └─ licenseFile: node_modules\data-urls\LICENSE.txt
-├─ debug@4.1.1
+├─ debug@4.3.4
 │  ├─ licenses: MIT
-│  ├─ repository: https://github.com/visionmedia/debug
-│  ├─ publisher: TJ Holowaychuk
-│  ├─ email: tj@vision-media.ca
-│  ├─ path: C:\dev\dnn-elements\node_modules\debug
+│  ├─ repository: https://github.com/debug-js/debug
+│  ├─ publisher: Josh Junon
+│  ├─ email: josh.junon@protonmail.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\debug
 │  └─ licenseFile: node_modules\debug\LICENSE
 ├─ debuglog@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sam-github/node-debuglog
 │  ├─ publisher: Sam Roberts
 │  ├─ email: sam@strongloop.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\debuglog
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\debuglog
 │  └─ licenseFile: node_modules\debuglog\LICENSE
 ├─ decimal.js@10.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/MikeMcl/decimal.js
 │  ├─ publisher: Michael Mclaughlin
 │  ├─ email: M8ch88l@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\decimal.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\decimal.js
 │  └─ licenseFile: node_modules\decimal.js\LICENCE.md
 ├─ decode-uri-component@0.2.0
 │  ├─ licenses: MIT
@@ -2995,7 +2997,7 @@
 │  ├─ publisher: Sam Verschueren
 │  ├─ email: sam.verschueren@gmail.com
 │  ├─ url: github.com/SamVerschueren
-│  ├─ path: C:\dev\dnn-elements\node_modules\decode-uri-component
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\decode-uri-component
 │  └─ licenseFile: node_modules\decode-uri-component\license
 ├─ dedent@0.7.0
 │  ├─ licenses: MIT
@@ -3003,7 +3005,7 @@
 │  ├─ publisher: Desmond Brand
 │  ├─ email: dmnd@desmondbrand.com
 │  ├─ url: http://desmondbrand.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\dedent
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\dedent
 │  └─ licenseFile: node_modules\dedent\LICENSE
 ├─ deep-equal@1.1.1
 │  ├─ licenses: MIT
@@ -3011,39 +3013,39 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\deep-equal
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\deep-equal
 │  └─ licenseFile: node_modules\deep-equal\LICENSE
-├─ deep-is@0.1.3
+├─ deep-is@0.1.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/thlorenz/deep-is
 │  ├─ publisher: Thorsten Lorenz
 │  ├─ email: thlorenz@gmx.de
 │  ├─ url: http://thlorenz.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\deep-is
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\deep-is
 │  └─ licenseFile: node_modules\deep-is\LICENSE
 ├─ deep-object-diff@1.1.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mattphillips/deep-object-diff
 │  ├─ publisher: Matt Phillips
-│  ├─ path: C:\dev\dnn-elements\node_modules\deep-object-diff
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\deep-object-diff
 │  └─ licenseFile: node_modules\deep-object-diff\LICENSE
 ├─ deepmerge@4.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/TehShrike/deepmerge
-│  ├─ path: C:\dev\dnn-elements\node_modules\deepmerge
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\deepmerge
 │  └─ licenseFile: node_modules\deepmerge\license.txt
 ├─ define-properties@1.1.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/define-properties
 │  ├─ publisher: Jordan Harband
-│  ├─ path: C:\dev\dnn-elements\node_modules\define-properties
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\define-properties
 │  └─ licenseFile: node_modules\define-properties\LICENSE
 ├─ define-property@2.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/define-property
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\define-property
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\define-property
 │  └─ licenseFile: node_modules\define-property\LICENSE
 ├─ delayed-stream@1.0.0
 │  ├─ licenses: MIT
@@ -3051,31 +3053,31 @@
 │  ├─ publisher: Felix Geisendörfer
 │  ├─ email: felix@debuggable.com
 │  ├─ url: http://debuggable.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\delayed-stream
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\delayed-stream
 │  └─ licenseFile: node_modules\delayed-stream\License
 ├─ delegate@3.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zenorocha/delegate
-│  ├─ path: C:\dev\dnn-elements\node_modules\delegate
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\delegate
 │  └─ licenseFile: node_modules\delegate\readme.md
 ├─ delegates@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/visionmedia/node-delegates
-│  ├─ path: C:\dev\dnn-elements\node_modules\delegates
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\delegates
 │  └─ licenseFile: node_modules\delegates\License
 ├─ depd@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/dougwilson/nodejs-depd
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\depd
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\depd
 │  └─ licenseFile: node_modules\depd\LICENSE
 ├─ des.js@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/indutny/des.js
 │  ├─ publisher: Fedor Indutny
 │  ├─ email: fedor@indutny.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\des.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\des.js
 │  └─ licenseFile: node_modules\des.js\README.md
 ├─ destroy@1.0.4
 │  ├─ licenses: MIT
@@ -3083,7 +3085,7 @@
 │  ├─ publisher: Jonathan Ong
 │  ├─ email: me@jongleberry.com
 │  ├─ url: http://jongleberry.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\destroy
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\destroy
 │  └─ licenseFile: node_modules\destroy\LICENSE
 ├─ detab@2.0.4
 │  ├─ licenses: MIT
@@ -3091,7 +3093,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\detab
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\detab
 │  └─ licenseFile: node_modules\detab\license
 ├─ detect-newline@3.1.0
 │  ├─ licenses: MIT
@@ -3099,24 +3101,24 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\detect-newline
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\detect-newline
 │  └─ licenseFile: node_modules\detect-newline\license
 ├─ detect-node-es@1.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/thekashey/detect-node
 │  ├─ publisher: Ilya Kantor
-│  ├─ path: C:\dev\dnn-elements\node_modules\detect-node-es
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\detect-node-es
 │  └─ licenseFile: node_modules\detect-node-es\LICENSE
 ├─ detect-port@1.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/node-modules/detect-port
-│  ├─ path: C:\dev\dnn-elements\node_modules\detect-port
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\detect-port
 │  └─ licenseFile: node_modules\detect-port\LICENSE
-├─ devtools-protocol@0.0.960912
+├─ devtools-protocol@0.0.969999
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/ChromeDevTools/devtools-protocol
 │  ├─ publisher: The Chromium Authors
-│  ├─ path: C:\dev\dnn-elements\node_modules\devtools-protocol
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\devtools-protocol
 │  └─ licenseFile: node_modules\devtools-protocol\LICENSE
 ├─ dezalgo@1.0.3
 │  ├─ licenses: ISC
@@ -3124,46 +3126,51 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\dezalgo
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\dezalgo
 │  └─ licenseFile: node_modules\dezalgo\LICENSE
+├─ diff-sequences@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\diff-sequences
+│  └─ licenseFile: node_modules\diff-sequences\LICENSE
 ├─ diffie-hellman@5.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/diffie-hellman
 │  ├─ publisher: Calvin Metcalf
-│  ├─ path: C:\dev\dnn-elements\node_modules\diffie-hellman
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\diffie-hellman
 │  └─ licenseFile: node_modules\diffie-hellman\LICENSE
-├─ dir-glob@3.0.1
+├─ dir-glob@2.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/kevva/dir-glob
 │  ├─ publisher: Kevin Mårtensson
 │  ├─ email: kevinmartensson@gmail.com
 │  ├─ url: github.com/kevva
-│  ├─ path: C:\dev\dnn-elements\node_modules\dir-glob
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\dir-glob
 │  └─ licenseFile: node_modules\dir-glob\license
-├─ doctrine@2.1.0
+├─ doctrine@3.0.0
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/eslint/doctrine
-│  ├─ path: C:\dev\dnn-elements\node_modules\doctrine
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\doctrine
 │  └─ licenseFile: node_modules\doctrine\LICENSE
 ├─ dom-converter@0.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/AriaMinaei/dom-converter
 │  ├─ publisher: Aria Minaei
-│  ├─ path: C:\dev\dnn-elements\node_modules\dom-converter
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\dom-converter
 │  └─ licenseFile: node_modules\dom-converter\LICENSE
 ├─ dom-serializer@1.3.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/cheeriojs/dom-renderer
 │  ├─ publisher: Felix Boehm
 │  ├─ email: me@feedic.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\dom-serializer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\dom-serializer
 │  └─ licenseFile: node_modules\dom-serializer\LICENSE
 ├─ dom-walk@0.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Raynos/dom-walk
 │  ├─ publisher: Raynos
 │  ├─ email: raynos2@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\dom-walk
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\dom-walk
 │  └─ licenseFile: node_modules\dom-walk\LICENCE
 ├─ domain-browser@1.2.0
 │  ├─ licenses: MIT
@@ -3171,14 +3178,14 @@
 │  ├─ publisher: 2013+ Bevry Pty Ltd
 │  ├─ email: us@bevry.me
 │  ├─ url: http://bevry.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\domain-browser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\domain-browser
 │  └─ licenseFile: node_modules\domain-browser\LICENSE.md
 ├─ domelementtype@2.2.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/fb55/domelementtype
 │  ├─ publisher: Felix Boehm
 │  ├─ email: me@feedic.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\domelementtype
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\domelementtype
 │  └─ licenseFile: node_modules\domelementtype\LICENSE
 ├─ domexception@2.0.1
 │  ├─ licenses: MIT
@@ -3186,21 +3193,21 @@
 │  ├─ publisher: Domenic Denicola
 │  ├─ email: d@domenic.me
 │  ├─ url: https://domenic.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\domexception
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\domexception
 │  └─ licenseFile: node_modules\domexception\LICENSE.txt
-├─ domhandler@3.3.0
+├─ domhandler@4.3.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/fb55/domhandler
 │  ├─ publisher: Felix Boehm
 │  ├─ email: me@feedic.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\domhandler
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\domhandler
 │  └─ licenseFile: node_modules\domhandler\LICENSE
 ├─ domutils@2.8.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/fb55/domutils
 │  ├─ publisher: Felix Boehm
 │  ├─ email: me@feedic.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\domutils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\domutils
 │  └─ licenseFile: node_modules\domutils\LICENSE
 ├─ dot-case@3.0.4
 │  ├─ licenses: MIT
@@ -3208,17 +3215,17 @@
 │  ├─ publisher: Blake Embrey
 │  ├─ email: hello@blakeembrey.com
 │  ├─ url: http://blakeembrey.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\dot-case
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\dot-case
 │  └─ licenseFile: node_modules\dot-case\LICENSE
 ├─ dotenv-expand@5.1.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ publisher: motdotla
-│  ├─ path: C:\dev\dnn-elements\node_modules\dotenv-expand
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\dotenv-expand
 │  └─ licenseFile: node_modules\dotenv-expand\LICENSE
 ├─ dotenv@8.6.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/motdotla/dotenv
-│  ├─ path: C:\dev\dnn-elements\node_modules\dotenv
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\dotenv
 │  └─ licenseFile: node_modules\dotenv\LICENSE
 ├─ downshift@6.1.7
 │  ├─ licenses: MIT
@@ -3226,13 +3233,13 @@
 │  ├─ publisher: Kent C. Dodds
 │  ├─ email: kent@doddsfamily.us
 │  ├─ url: http://kentcdodds.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\downshift
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\downshift
 │  └─ licenseFile: node_modules\downshift\LICENSE
 ├─ duplexify@3.7.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/duplexify
 │  ├─ publisher: Mathias Buus
-│  ├─ path: C:\dev\dnn-elements\node_modules\duplexify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\duplexify
 │  └─ licenseFile: node_modules\duplexify\LICENSE
 ├─ ee-first@1.1.1
 │  ├─ licenses: MIT
@@ -3240,25 +3247,25 @@
 │  ├─ publisher: Jonathan Ong
 │  ├─ email: me@jongleberry.com
 │  ├─ url: http://jongleberry.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\ee-first
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ee-first
 │  └─ licenseFile: node_modules\ee-first\LICENSE
-├─ electron-to-chromium@1.4.82
+├─ electron-to-chromium@1.4.88
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/kilian/electron-to-chromium
 │  ├─ publisher: Kilian Valkhof
-│  ├─ path: C:\dev\dnn-elements\node_modules\electron-to-chromium
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\electron-to-chromium
 │  └─ licenseFile: node_modules\electron-to-chromium\LICENSE
 ├─ element-resize-detector@1.2.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/wnr/element-resize-detector
-│  ├─ path: C:\dev\dnn-elements\node_modules\element-resize-detector
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\element-resize-detector
 │  └─ licenseFile: node_modules\element-resize-detector\LICENSE
 ├─ elliptic@6.5.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/indutny/elliptic
 │  ├─ publisher: Fedor Indutny
 │  ├─ email: fedor@indutny.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\elliptic
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\elliptic
 │  └─ licenseFile: node_modules\elliptic\README.md
 ├─ emittery@0.8.1
 │  ├─ licenses: MIT
@@ -3266,14 +3273,14 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\emittery
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\emittery
 │  └─ licenseFile: node_modules\emittery\license
 ├─ emoji-regex@8.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/emoji-regex
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\emoji-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\emoji-regex
 │  └─ licenseFile: node_modules\emoji-regex\LICENSE-MIT.txt
 ├─ emojis-list@3.0.0
 │  ├─ licenses: MIT
@@ -3281,55 +3288,55 @@
 │  ├─ publisher: Kiko Beats
 │  ├─ email: josefrancisco.verdu@gmail.com
 │  ├─ url: https://github.com/Kikobeats
-│  ├─ path: C:\dev\dnn-elements\node_modules\emojis-list
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\emojis-list
 │  └─ licenseFile: node_modules\emojis-list\LICENSE.md
 ├─ emotion-theming@10.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/emotion-js/emotion/tree/master/packages/emotion-theming
 │  ├─ publisher: styled-components team
-│  ├─ path: C:\dev\dnn-elements\node_modules\emotion-theming
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\emotion-theming
 │  └─ licenseFile: node_modules\emotion-theming\LICENSE
 ├─ encodeurl@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/pillarjs/encodeurl
-│  ├─ path: C:\dev\dnn-elements\node_modules\encodeurl
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\encodeurl
 │  └─ licenseFile: node_modules\encodeurl\LICENSE
 ├─ end-of-stream@1.4.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/end-of-stream
 │  ├─ publisher: Mathias Buus
 │  ├─ email: mathiasbuus@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\end-of-stream
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\end-of-stream
 │  └─ licenseFile: node_modules\end-of-stream\LICENSE
 ├─ enhanced-resolve@4.5.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/enhanced-resolve
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\enhanced-resolve
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\enhanced-resolve
 │  └─ licenseFile: node_modules\enhanced-resolve\LICENSE
 ├─ enquirer@2.3.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/enquirer/enquirer
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\enquirer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\enquirer
 │  └─ licenseFile: node_modules\enquirer\LICENSE
 ├─ entities@2.2.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/fb55/entities
 │  ├─ publisher: Felix Boehm
 │  ├─ email: me@feedic.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\entities
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\entities
 │  └─ licenseFile: node_modules\entities\LICENSE
 ├─ errno@0.1.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/rvagg/node-errno
-│  ├─ path: C:\dev\dnn-elements\node_modules\errno
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\errno
 │  └─ licenseFile: node_modules\errno\README.md
 ├─ error-ex@1.3.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/qix-/node-error-ex
-│  ├─ path: C:\dev\dnn-elements\node_modules\error-ex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\error-ex
 │  └─ licenseFile: node_modules\error-ex\LICENSE
 ├─ es-abstract@1.19.1
 │  ├─ licenses: MIT
@@ -3337,40 +3344,40 @@
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
 │  ├─ url: http://ljharb.codes
-│  ├─ path: C:\dev\dnn-elements\node_modules\es-abstract
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\es-abstract
 │  └─ licenseFile: node_modules\es-abstract\LICENSE
 ├─ es-array-method-boxes-properly@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/es-array-method-boxes-properly
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\es-array-method-boxes-properly
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\es-array-method-boxes-properly
 │  └─ licenseFile: node_modules\es-array-method-boxes-properly\LICENSE
 ├─ es-get-iterator@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/es-get-iterator
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\es-get-iterator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\es-get-iterator
 │  └─ licenseFile: node_modules\es-get-iterator\LICENSE
 ├─ es-to-primitive@1.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/es-to-primitive
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\es-to-primitive
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\es-to-primitive
 │  └─ licenseFile: node_modules\es-to-primitive\LICENSE
 ├─ es5-shim@4.6.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/es5-shim
-│  ├─ path: C:\dev\dnn-elements\node_modules\es5-shim
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\es5-shim
 │  └─ licenseFile: node_modules\es5-shim\LICENSE
 ├─ es6-shim@0.35.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/paulmillr/es6-shim
 │  ├─ publisher: Paul Miller
 │  ├─ url: http://paulmillr.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\es6-shim
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\es6-shim
 │  └─ licenseFile: node_modules\es6-shim\LICENSE
 ├─ escalade@3.1.1
 │  ├─ licenses: MIT
@@ -3378,12 +3385,12 @@
 │  ├─ publisher: Luke Edwards
 │  ├─ email: luke.edwards05@gmail.com
 │  ├─ url: https://lukeed.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\escalade
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\escalade
 │  └─ licenseFile: node_modules\escalade\license
 ├─ escape-html@1.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/component/escape-html
-│  ├─ path: C:\dev\dnn-elements\node_modules\escape-html
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\escape-html
 │  └─ licenseFile: node_modules\escape-html\LICENSE
 ├─ escape-string-regexp@1.0.5
 │  ├─ licenses: MIT
@@ -3391,85 +3398,85 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\escape-string-regexp
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\escape-string-regexp
 │  └─ licenseFile: node_modules\escape-string-regexp\license
 ├─ escodegen@2.0.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/estools/escodegen
-│  ├─ path: C:\dev\dnn-elements\node_modules\escodegen
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\escodegen
 │  └─ licenseFile: node_modules\escodegen\LICENSE.BSD
-├─ eslint-plugin-react@7.29.3
+├─ eslint-plugin-react@7.29.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/yannickcr/eslint-plugin-react
 │  ├─ publisher: Yannick Croissant
 │  ├─ email: yannick.croissant+npm@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\eslint-plugin-react
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\eslint-plugin-react
 │  └─ licenseFile: node_modules\eslint-plugin-react\LICENSE
 ├─ eslint-scope@4.0.3
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/eslint/eslint-scope
-│  ├─ path: C:\dev\dnn-elements\node_modules\eslint-scope
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\eslint-scope
 │  └─ licenseFile: node_modules\eslint-scope\LICENSE
-├─ eslint-utils@2.1.0
+├─ eslint-utils@3.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mysticatea/eslint-utils
 │  ├─ publisher: Toru Nagashima
-│  ├─ path: C:\dev\dnn-elements\node_modules\eslint-utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\eslint-utils
 │  └─ licenseFile: node_modules\eslint-utils\LICENSE
-├─ eslint-visitor-keys@1.1.0
+├─ eslint-visitor-keys@2.1.0
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/eslint/eslint-visitor-keys
 │  ├─ publisher: Toru Nagashima
 │  ├─ url: https://github.com/mysticatea
-│  ├─ path: C:\dev\dnn-elements\node_modules\eslint-visitor-keys
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\eslint-visitor-keys
 │  └─ licenseFile: node_modules\eslint-visitor-keys\LICENSE
 ├─ eslint@7.32.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/eslint/eslint
 │  ├─ publisher: Nicholas C. Zakas
 │  ├─ email: nicholas+npm@nczconsulting.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\eslint
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\eslint
 │  └─ licenseFile: node_modules\eslint\LICENSE
 ├─ espree@7.3.1
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/eslint/espree
 │  ├─ publisher: Nicholas C. Zakas
 │  ├─ email: nicholas+npm@nczconsulting.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\espree
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\espree
 │  └─ licenseFile: node_modules\espree\LICENSE
 ├─ esprima@4.0.1
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/jquery/esprima
 │  ├─ publisher: Ariya Hidayat
 │  ├─ email: ariya.hidayat@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\esprima
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\esprima
 │  └─ licenseFile: node_modules\esprima\LICENSE.BSD
 ├─ esquery@1.4.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/estools/esquery
 │  ├─ publisher: Joel Feenstra
 │  ├─ email: jrfeenst+esquery@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\esquery
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\esquery
 │  └─ licenseFile: node_modules\esquery\license.txt
 ├─ esrecurse@4.3.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/estools/esrecurse
-│  ├─ path: C:\dev\dnn-elements\node_modules\esrecurse
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\esrecurse
 │  └─ licenseFile: node_modules\esrecurse\README.md
 ├─ estraverse@4.3.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/estools/estraverse
-│  ├─ path: C:\dev\dnn-elements\node_modules\estraverse
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\estraverse
 │  └─ licenseFile: node_modules\estraverse\LICENSE.BSD
 ├─ esutils@2.0.3
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/estools/esutils
-│  ├─ path: C:\dev\dnn-elements\node_modules\esutils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\esutils
 │  └─ licenseFile: node_modules\esutils\LICENSE.BSD
 ├─ etag@1.8.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/etag
-│  ├─ path: C:\dev\dnn-elements\node_modules\etag
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\etag
 │  └─ licenseFile: node_modules\etag\LICENSE
 ├─ events@3.3.0
 │  ├─ licenses: MIT
@@ -3477,62 +3484,62 @@
 │  ├─ publisher: Irakli Gozalishvili
 │  ├─ email: rfobic@gmail.com
 │  ├─ url: http://jeditoolkit.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\events
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\events
 │  └─ licenseFile: node_modules\events\LICENSE
 ├─ evp_bytestokey@1.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/EVP_BytesToKey
 │  ├─ publisher: Calvin Metcalf
 │  ├─ email: calvin.metcalf@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\evp_bytestokey
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\evp_bytestokey
 │  └─ licenseFile: node_modules\evp_bytestokey\LICENSE
 ├─ exec-sh@0.3.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/tsertkov/exec-sh
 │  ├─ publisher: Aleksandr Tsertkov
 │  ├─ email: tsertkov@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\exec-sh
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\exec-sh
 │  └─ licenseFile: node_modules\exec-sh\LICENSE
-├─ execa@5.1.1
+├─ execa@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/execa
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\execa
+│  ├─ url: sindresorhus.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\execa
 │  └─ licenseFile: node_modules\execa\license
 ├─ exit@0.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/cowboy/node-exit
 │  ├─ publisher: "Cowboy" Ben Alman
 │  ├─ url: http://benalman.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\exit
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\exit
 │  └─ licenseFile: node_modules\exit\LICENSE-MIT
 ├─ expand-brackets@2.1.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/expand-brackets
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\expand-brackets
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\expand-brackets
 │  └─ licenseFile: node_modules\expand-brackets\LICENSE
 ├─ expect@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\expect
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\expect
 │  └─ licenseFile: node_modules\expect\LICENSE
 ├─ express@4.17.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/expressjs/express
 │  ├─ publisher: TJ Holowaychuk
 │  ├─ email: tj@vision-media.ca
-│  ├─ path: C:\dev\dnn-elements\node_modules\express
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\express
 │  └─ licenseFile: node_modules\express\LICENSE
 ├─ extend-shallow@3.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/extend-shallow
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\extend-shallow
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\extend-shallow
 │  └─ licenseFile: node_modules\extend-shallow\LICENSE
 ├─ extend@3.0.2
 │  ├─ licenses: MIT
@@ -3540,41 +3547,41 @@
 │  ├─ publisher: Stefan Thomas
 │  ├─ email: justmoon@members.fsf.org
 │  ├─ url: http://www.justmoon.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\extend
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\extend
 │  └─ licenseFile: node_modules\extend\LICENSE
 ├─ extglob@2.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/micromatch/extglob
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\extglob
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\extglob
 │  └─ licenseFile: node_modules\extglob\LICENSE
 ├─ extract-zip@2.0.1
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/maxogden/extract-zip
 │  ├─ publisher: max ogden
-│  ├─ path: C:\dev\dnn-elements\node_modules\extract-zip
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\extract-zip
 │  └─ licenseFile: node_modules\extract-zip\LICENSE
 ├─ fast-deep-equal@3.1.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/epoberezkin/fast-deep-equal
 │  ├─ publisher: Evgeny Poberezkin
-│  ├─ path: C:\dev\dnn-elements\node_modules\fast-deep-equal
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fast-deep-equal
 │  └─ licenseFile: node_modules\fast-deep-equal\LICENSE
-├─ fast-glob@3.2.7
+├─ fast-glob@2.2.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mrmlnc/fast-glob
 │  ├─ publisher: Denis Malinochkin
-│  ├─ url: https://mrmlnc.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\fast-glob
+│  ├─ url: canonium.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fast-glob
 │  └─ licenseFile: node_modules\fast-glob\LICENSE
-├─ fast-json-stable-stringify@2.0.0
+├─ fast-json-stable-stringify@2.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/epoberezkin/fast-json-stable-stringify
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\fast-json-stable-stringify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fast-json-stable-stringify
 │  └─ licenseFile: node_modules\fast-json-stable-stringify\LICENSE
 ├─ fast-levenshtein@2.0.6
 │  ├─ licenses: MIT
@@ -3582,14 +3589,14 @@
 │  ├─ publisher: Ramesh Nair
 │  ├─ email: ram@hiddentao.com
 │  ├─ url: http://www.hiddentao.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\fast-levenshtein
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fast-levenshtein
 │  └─ licenseFile: node_modules\fast-levenshtein\LICENSE.md
 ├─ fastq@1.13.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/mcollina/fastq
 │  ├─ publisher: Matteo Collina
 │  ├─ email: hello@matteocollina.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\fastq
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fastq
 │  └─ licenseFile: node_modules\fastq\LICENSE
 ├─ fault@1.0.4
 │  ├─ licenses: MIT
@@ -3597,7 +3604,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\fault
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fault
 │  └─ licenseFile: node_modules\fault\license
 ├─ fb-watchman@2.0.1
 │  ├─ licenses: Apache-2.0
@@ -3605,34 +3612,34 @@
 │  ├─ publisher: Wez Furlong
 │  ├─ email: wez@fb.com
 │  ├─ url: http://wezfurlong.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\fb-watchman
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fb-watchman
 │  └─ licenseFile: node_modules\fb-watchman\README.md
 ├─ fd-slicer@1.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/andrewrk/node-fd-slicer
 │  ├─ publisher: Andrew Kelley
 │  ├─ email: superjoe30@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\fd-slicer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fd-slicer
 │  └─ licenseFile: node_modules\fd-slicer\LICENSE
 ├─ figgy-pudding@3.5.2
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/npm/figgy-pudding
 │  ├─ publisher: Kat Marchán
 │  ├─ email: kzm@sykosomatic.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\figgy-pudding
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\figgy-pudding
 │  └─ licenseFile: node_modules\figgy-pudding\LICENSE.md
 ├─ file-entry-cache@6.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/royriojas/file-entry-cache
 │  ├─ publisher: Roy Riojas
 │  ├─ url: http://royriojas.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\file-entry-cache
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\file-entry-cache
 │  └─ licenseFile: node_modules\file-entry-cache\LICENSE
 ├─ file-loader@6.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack-contrib/file-loader
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\file-loader
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\file-loader
 │  └─ licenseFile: node_modules\file-loader\LICENSE
 ├─ file-system-cache@1.0.5
 │  ├─ licenses: MIT
@@ -3640,32 +3647,32 @@
 │  ├─ publisher: Phil Cockfield
 │  ├─ email: phil@cockfield.net
 │  ├─ url: https://github.com/philcockfield
-│  ├─ path: C:\dev\dnn-elements\node_modules\file-system-cache
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\file-system-cache
 │  └─ licenseFile: node_modules\file-system-cache\LICENSE
 ├─ fill-range@7.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/fill-range
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\fill-range
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fill-range
 │  └─ licenseFile: node_modules\fill-range\LICENSE
 ├─ finalhandler@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/pillarjs/finalhandler
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\finalhandler
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\finalhandler
 │  └─ licenseFile: node_modules\finalhandler\LICENSE
 ├─ find-cache-dir@2.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/avajs/find-cache-dir
-│  ├─ path: C:\dev\dnn-elements\node_modules\find-cache-dir
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\find-cache-dir
 │  └─ licenseFile: node_modules\find-cache-dir\license
 ├─ find-root@1.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/js-n/find-root
 │  ├─ publisher: jsdnxx
-│  ├─ path: C:\dev\dnn-elements\node_modules\find-root
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\find-root
 │  └─ licenseFile: node_modules\find-root\LICENSE.md
 ├─ find-up@4.1.0
 │  ├─ licenses: MIT
@@ -3673,48 +3680,48 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\find-up
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\find-up
 │  └─ licenseFile: node_modules\find-up\license
 ├─ flat-cache@3.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/royriojas/flat-cache
 │  ├─ publisher: Roy Riojas
 │  ├─ url: http://royriojas.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\flat-cache
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\flat-cache
 │  └─ licenseFile: node_modules\flat-cache\LICENSE
-├─ flatted@3.2.4
+├─ flatted@3.2.5
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/WebReflection/flatted
 │  ├─ publisher: Andrea Giammarchi
-│  ├─ path: C:\dev\dnn-elements\node_modules\flatted
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\flatted
 │  └─ licenseFile: node_modules\flatted\LICENSE
 ├─ flush-write-stream@1.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/flush-write-stream
 │  ├─ publisher: Mathias Buus
 │  ├─ url: @mafintosh
-│  ├─ path: C:\dev\dnn-elements\node_modules\flush-write-stream
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\flush-write-stream
 │  └─ licenseFile: node_modules\flush-write-stream\LICENSE
 ├─ focus-lock@0.10.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/theKashey/focus-lock
 │  ├─ publisher: theKashey
 │  ├─ email: thekashey@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\focus-lock
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\focus-lock
 │  └─ licenseFile: node_modules\focus-lock\LICENSE
 ├─ for-in@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/for-in
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\for-in
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\for-in
 │  └─ licenseFile: node_modules\for-in\LICENSE
-├─ fork-ts-checker-webpack-plugin@4.1.6
+├─ fork-ts-checker-webpack-plugin@6.5.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/TypeStrong/fork-ts-checker-webpack-plugin
 │  ├─ publisher: Piotr Oleś
 │  ├─ email: piotrek.oles@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\fork-ts-checker-webpack-plugin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fork-ts-checker-webpack-plugin
 │  └─ licenseFile: node_modules\fork-ts-checker-webpack-plugin\LICENSE
 ├─ form-data@3.0.1
 │  ├─ licenses: MIT
@@ -3722,26 +3729,26 @@
 │  ├─ publisher: Felix Geisendörfer
 │  ├─ email: felix@debuggable.com
 │  ├─ url: http://debuggable.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\form-data
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\form-data
 │  └─ licenseFile: node_modules\form-data\License
 ├─ format@0.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/samsonjs/format
 │  ├─ publisher: Sami Samhuri
 │  ├─ email: sami@samhuri.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\format
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\format
 │  └─ licenseFile: node_modules\format\Readme.md
 ├─ forwarded@0.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/forwarded
-│  ├─ path: C:\dev\dnn-elements\node_modules\forwarded
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\forwarded
 │  └─ licenseFile: node_modules\forwarded\LICENSE
 ├─ fragment-cache@0.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/fragment-cache
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\fragment-cache
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fragment-cache
 │  └─ licenseFile: node_modules\fragment-cache\LICENSE
 ├─ fresh@0.5.2
 │  ├─ licenses: MIT
@@ -3749,7 +3756,7 @@
 │  ├─ publisher: TJ Holowaychuk
 │  ├─ email: tj@vision-media.ca
 │  ├─ url: http://tjholowaychuk.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\fresh
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fresh
 │  └─ licenseFile: node_modules\fresh\LICENSE
 ├─ from2@2.3.0
 │  ├─ licenses: MIT
@@ -3757,21 +3764,21 @@
 │  ├─ publisher: Hugh Kennedy
 │  ├─ email: hughskennedy@gmail.com
 │  ├─ url: http://hughsk.io/
-│  ├─ path: C:\dev\dnn-elements\node_modules\from2
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\from2
 │  └─ licenseFile: node_modules\from2\LICENSE.md
 ├─ fs-constants@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/fs-constants
 │  ├─ publisher: Mathias Buus
 │  ├─ url: @mafintosh
-│  ├─ path: C:\dev\dnn-elements\node_modules\fs-constants
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fs-constants
 │  └─ licenseFile: node_modules\fs-constants\LICENSE
 ├─ fs-extra@9.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jprichardson/node-fs-extra
 │  ├─ publisher: JP Richardson
 │  ├─ email: jprichardson@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\fs-extra
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fs-extra
 │  └─ licenseFile: node_modules\fs-extra\LICENSE
 ├─ fs-minipass@2.1.0
 │  ├─ licenses: ISC
@@ -3779,12 +3786,12 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\fs-minipass
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fs-minipass
 │  └─ licenseFile: node_modules\fs-minipass\LICENSE
 ├─ fs-monkey@1.0.3
 │  ├─ licenses: Unlicense
 │  ├─ repository: https://github.com/streamich/fs-monkey
-│  ├─ path: C:\dev\dnn-elements\node_modules\fs-monkey
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fs-monkey
 │  └─ licenseFile: node_modules\fs-monkey\LICENSE
 ├─ fs-write-stream-atomic@1.0.10
 │  ├─ licenses: ISC
@@ -3792,7 +3799,7 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\fs-write-stream-atomic
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fs-write-stream-atomic
 │  └─ licenseFile: node_modules\fs-write-stream-atomic\LICENSE
 ├─ fs.realpath@1.0.0
 │  ├─ licenses: ISC
@@ -3800,34 +3807,34 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\fs.realpath
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fs.realpath
 │  └─ licenseFile: node_modules\fs.realpath\LICENSE
 ├─ function-bind@1.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Raynos/function-bind
 │  ├─ publisher: Raynos
 │  ├─ email: raynos2@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\function-bind
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\function-bind
 │  └─ licenseFile: node_modules\function-bind\LICENSE
 ├─ function.prototype.name@1.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/Function.prototype.name
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\function.prototype.name
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\function.prototype.name
 │  └─ licenseFile: node_modules\function.prototype.name\LICENSE
 ├─ functional-red-black-tree@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mikolalysenko/functional-red-black-tree
 │  ├─ publisher: Mikola Lysenko
-│  ├─ path: C:\dev\dnn-elements\node_modules\functional-red-black-tree
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\functional-red-black-tree
 │  └─ licenseFile: node_modules\functional-red-black-tree\LICENSE
 ├─ functions-have-names@1.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/functions-have-names
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\functions-have-names
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\functions-have-names
 │  └─ licenseFile: node_modules\functions-have-names\LICENSE
 ├─ fuse.js@3.6.1
 │  ├─ licenses: Apache-2.0
@@ -3835,69 +3842,69 @@
 │  ├─ publisher: Kirollos Risk
 │  ├─ email: kirollos@gmail.com
 │  ├─ url: http://kiro.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\fuse.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fuse.js
 │  └─ licenseFile: node_modules\fuse.js\LICENSE
 ├─ gauge@3.0.2
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/iarna/gauge
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\gauge
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\gauge
 │  └─ licenseFile: node_modules\gauge\LICENSE
 ├─ gensync@1.0.0-beta.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/loganfsmyth/gensync
 │  ├─ publisher: Logan Smyth
 │  ├─ email: loganfsmyth@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\gensync
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\gensync
 │  └─ licenseFile: node_modules\gensync\LICENSE
 ├─ get-caller-file@2.0.5
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/stefanpenner/get-caller-file
 │  ├─ publisher: Stefan Penner
-│  ├─ path: C:\dev\dnn-elements\node_modules\get-caller-file
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\get-caller-file
 │  └─ licenseFile: node_modules\get-caller-file\LICENSE.md
 ├─ get-intrinsic@1.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/get-intrinsic
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\get-intrinsic
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\get-intrinsic
 │  └─ licenseFile: node_modules\get-intrinsic\LICENSE
 ├─ get-package-type@0.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/cfware/get-package-type
 │  ├─ publisher: Corey Farrell
-│  ├─ path: C:\dev\dnn-elements\node_modules\get-package-type
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\get-package-type
 │  └─ licenseFile: node_modules\get-package-type\LICENSE
-├─ get-stream@6.0.1
+├─ get-stream@4.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/get-stream
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\get-stream
+│  ├─ url: sindresorhus.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\get-stream
 │  └─ licenseFile: node_modules\get-stream\license
 ├─ get-symbol-description@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/get-symbol-description
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\get-symbol-description
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\get-symbol-description
 │  └─ licenseFile: node_modules\get-symbol-description\LICENSE
 ├─ get-value@2.0.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/get-value
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\get-value
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\get-value
 │  └─ licenseFile: node_modules\get-value\LICENSE
 ├─ github-slugger@1.4.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/Flet/github-slugger
 │  ├─ publisher: Dan Flettre
 │  ├─ email: flettre@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\github-slugger
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\github-slugger
 │  └─ licenseFile: node_modules\github-slugger\LICENSE
 ├─ glob-parent@5.1.2
 │  ├─ licenses: ISC
@@ -3905,7 +3912,7 @@
 │  ├─ publisher: Gulp Team
 │  ├─ email: team@gulpjs.com
 │  ├─ url: https://gulpjs.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\glob-parent
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\glob-parent
 │  └─ licenseFile: node_modules\glob-parent\LICENSE
 ├─ glob-promise@3.4.0
 │  ├─ licenses: ISC
@@ -3913,105 +3920,105 @@
 │  ├─ publisher: Ahmad Nassri
 │  ├─ email: ahmad@ahmadnassri.com
 │  ├─ url: https://www.ahmadnassri.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\glob-promise
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\glob-promise
 │  └─ licenseFile: node_modules\glob-promise\LICENSE
-├─ glob-to-regexp@0.4.1
-│  ├─ licenses: BSD-2-Clause
+├─ glob-to-regexp@0.3.0
+│  ├─ licenses: BSD*
 │  ├─ repository: https://github.com/fitzgen/glob-to-regexp
 │  ├─ publisher: Nick Fitzgerald
 │  ├─ email: fitzgen@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\glob-to-regexp
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\glob-to-regexp
 │  └─ licenseFile: node_modules\glob-to-regexp\README.md
-├─ glob@7.1.6
+├─ glob@7.2.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/node-glob
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\glob
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\glob
 │  └─ licenseFile: node_modules\glob\LICENSE
 ├─ global@4.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Raynos/global
 │  ├─ publisher: Raynos
 │  ├─ email: raynos2@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\global
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\global
 │  └─ licenseFile: node_modules\global\LICENSE
-├─ globals@13.12.0
+├─ globals@11.12.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/globals
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\globals
+│  ├─ url: sindresorhus.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\globals
 │  └─ licenseFile: node_modules\globals\license
 ├─ globalthis@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/System.global
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\globalthis
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\globalthis
 │  └─ licenseFile: node_modules\globalthis\LICENSE
-├─ globby@11.0.4
+├─ globby@11.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/globby
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\globby
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\globby
 │  └─ licenseFile: node_modules\globby\license
 ├─ good-listener@1.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zenorocha/good-listener
-│  ├─ path: C:\dev\dnn-elements\node_modules\good-listener
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\good-listener
 │  └─ licenseFile: node_modules\good-listener\readme.md
-├─ graceful-fs@4.2.8
+├─ graceful-fs@4.2.9
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/node-graceful-fs
-│  ├─ path: C:\dev\dnn-elements\node_modules\graceful-fs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\graceful-fs
 │  └─ licenseFile: node_modules\graceful-fs\LICENSE
 ├─ gud@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jamiebuilds/global-unique-id
 │  ├─ publisher: Jamie Kyle
 │  ├─ email: me@thejameskyle.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\gud
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\gud
 │  └─ licenseFile: node_modules\gud\README.md
 ├─ handlebars@4.7.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/wycats/handlebars.js
 │  ├─ publisher: Yehuda Katz
-│  ├─ path: C:\dev\dnn-elements\node_modules\handlebars
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\handlebars
 │  └─ licenseFile: node_modules\handlebars\LICENSE
 ├─ has-bigints@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/has-bigints
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\has-bigints
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has-bigints
 │  └─ licenseFile: node_modules\has-bigints\LICENSE
-├─ has-flag@4.0.0
+├─ has-flag@3.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/has-flag
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\has-flag
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has-flag
 │  └─ licenseFile: node_modules\has-flag\license
 ├─ has-glob@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/has-glob
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\has-glob
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has-glob
 │  └─ licenseFile: node_modules\has-glob\LICENSE
-├─ has-symbols@1.0.2
+├─ has-symbols@1.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/has-symbols
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
 │  ├─ url: http://ljharb.codes
-│  ├─ path: C:\dev\dnn-elements\node_modules\has-symbols
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has-symbols
 │  └─ licenseFile: node_modules\has-symbols\LICENSE
 ├─ has-tostringtag@1.0.0
 │  ├─ licenses: MIT
@@ -4019,35 +4026,35 @@
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
 │  ├─ url: http://ljharb.codes
-│  ├─ path: C:\dev\dnn-elements\node_modules\has-tostringtag
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has-tostringtag
 │  └─ licenseFile: node_modules\has-tostringtag\LICENSE
 ├─ has-unicode@2.0.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/iarna/has-unicode
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\has-unicode
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has-unicode
 │  └─ licenseFile: node_modules\has-unicode\LICENSE
 ├─ has-value@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/has-value
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\has-value
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has-value
 │  └─ licenseFile: node_modules\has-value\LICENSE
 ├─ has-values@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/has-values
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\has-values
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has-values
 │  └─ licenseFile: node_modules\has-values\LICENSE
 ├─ has@1.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/tarruda/has
 │  ├─ publisher: Thiago de Arruda
 │  ├─ email: tpadilha84@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\has
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has
 │  └─ licenseFile: node_modules\has\LICENSE-MIT
 ├─ hash-base@3.1.0
 │  ├─ licenses: MIT
@@ -4055,14 +4062,14 @@
 │  ├─ publisher: Kirill Fomichev
 │  ├─ email: fanatid@ya.ru
 │  ├─ url: https://github.com/fanatid
-│  ├─ path: C:\dev\dnn-elements\node_modules\hash-base
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\hash-base
 │  └─ licenseFile: node_modules\hash-base\LICENSE
 ├─ hash.js@1.1.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/indutny/hash.js
 │  ├─ publisher: Fedor Indutny
 │  ├─ email: fedor@indutny.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\hash.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\hash.js
 │  └─ licenseFile: node_modules\hash.js\README.md
 ├─ hast-to-hyperscript@9.0.1
 │  ├─ licenses: MIT
@@ -4070,7 +4077,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\hast-to-hyperscript
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\hast-to-hyperscript
 │  └─ licenseFile: node_modules\hast-to-hyperscript\license
 ├─ hast-util-from-parse5@6.0.1
 │  ├─ licenses: MIT
@@ -4078,7 +4085,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\hast-util-from-parse5
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\hast-util-from-parse5
 │  └─ licenseFile: node_modules\hast-util-from-parse5\license
 ├─ hast-util-parse-selector@2.2.5
 │  ├─ licenses: MIT
@@ -4086,7 +4093,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\hast-util-parse-selector
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\hast-util-parse-selector
 │  └─ licenseFile: node_modules\hast-util-parse-selector\license
 ├─ hast-util-raw@6.0.1
 │  ├─ licenses: MIT
@@ -4094,7 +4101,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\hast-util-raw
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\hast-util-raw
 │  └─ licenseFile: node_modules\hast-util-raw\license
 ├─ hast-util-to-parse5@6.0.0
 │  ├─ licenses: MIT
@@ -4102,7 +4109,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\hast-util-to-parse5
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\hast-util-to-parse5
 │  └─ licenseFile: node_modules\hast-util-to-parse5\license
 ├─ hastscript@6.0.0
 │  ├─ licenses: MIT
@@ -4110,42 +4117,42 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\hastscript
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\hastscript
 │  └─ licenseFile: node_modules\hastscript\license
 ├─ he@1.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/he
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\he
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\he
 │  └─ licenseFile: node_modules\he\LICENSE-MIT.txt
 ├─ highlight.js@10.7.3
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/highlightjs/highlight.js
 │  ├─ publisher: Ivan Sagalaev
 │  ├─ email: maniac@softwaremaniacs.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\highlight.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\highlight.js
 │  └─ licenseFile: node_modules\highlight.js\LICENSE
 ├─ history@5.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ReactTraining/history
 │  ├─ publisher: React Training
 │  ├─ email: hello@reacttraining.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\history
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\history
 │  └─ licenseFile: node_modules\history\LICENSE
 ├─ hmac-drbg@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/indutny/hmac-drbg
 │  ├─ publisher: Fedor Indutny
 │  ├─ email: fedor@indutny.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\hmac-drbg
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\hmac-drbg
 │  └─ licenseFile: node_modules\hmac-drbg\README.md
 ├─ hoist-non-react-statics@3.3.2
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/mridgway/hoist-non-react-statics
 │  ├─ publisher: Michael Ridgway
 │  ├─ email: mcridgway@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\hoist-non-react-statics
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\hoist-non-react-statics
 │  └─ licenseFile: node_modules\hoist-non-react-statics\LICENSE.md
 ├─ hosted-git-info@2.8.9
 │  ├─ licenses: ISC
@@ -4153,7 +4160,7 @@
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
 │  ├─ url: http://re-becca.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\hosted-git-info
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\hosted-git-info
 │  └─ licenseFile: node_modules\hosted-git-info\LICENSE
 ├─ html-encoding-sniffer@2.0.1
 │  ├─ licenses: MIT
@@ -4161,32 +4168,32 @@
 │  ├─ publisher: Domenic Denicola
 │  ├─ email: d@domenic.me
 │  ├─ url: https://domenic.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\html-encoding-sniffer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\html-encoding-sniffer
 │  └─ licenseFile: node_modules\html-encoding-sniffer\LICENSE.txt
 ├─ html-entities@2.3.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mdevils/html-entities
 │  ├─ publisher: Marat Dulin
 │  ├─ email: mdevils@yandex.ru
-│  ├─ path: C:\dev\dnn-elements\node_modules\html-entities
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\html-entities
 │  └─ licenseFile: node_modules\html-entities\LICENSE
 ├─ html-escaper@2.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/WebReflection/html-escaper
 │  ├─ publisher: Andrea Giammarchi
-│  ├─ path: C:\dev\dnn-elements\node_modules\html-escaper
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\html-escaper
 │  └─ licenseFile: node_modules\html-escaper\LICENSE.txt
 ├─ html-loader@1.3.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack-contrib/html-loader
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\html-loader
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\html-loader
 │  └─ licenseFile: node_modules\html-loader\LICENSE
 ├─ html-minifier-terser@5.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DanielRuf/html-minifier-terser
 │  ├─ publisher: Daniel Ruf
-│  ├─ path: C:\dev\dnn-elements\node_modules\html-minifier-terser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\html-minifier-terser
 │  └─ licenseFile: node_modules\html-minifier-terser\LICENSE
 ├─ html-tags@3.1.0
 │  ├─ licenses: MIT
@@ -4194,7 +4201,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\html-tags
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\html-tags
 │  └─ licenseFile: node_modules\html-tags\license
 ├─ html-void-elements@1.0.5
 │  ├─ licenses: MIT
@@ -4202,7 +4209,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\html-void-elements
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\html-void-elements
 │  └─ licenseFile: node_modules\html-void-elements\license
 ├─ html-webpack-plugin@4.5.2
 │  ├─ licenses: MIT
@@ -4210,14 +4217,14 @@
 │  ├─ publisher: Jan Nicklas
 │  ├─ email: j.nicklas@me.com
 │  ├─ url: https://github.com/jantimon
-│  ├─ path: C:\dev\dnn-elements\node_modules\html-webpack-plugin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\html-webpack-plugin
 │  └─ licenseFile: node_modules\html-webpack-plugin\LICENSE
-├─ htmlparser2@4.1.0
+├─ htmlparser2@6.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/fb55/htmlparser2
 │  ├─ publisher: Felix Boehm
 │  ├─ email: me@feedic.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\htmlparser2
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\htmlparser2
 │  └─ licenseFile: node_modules\htmlparser2\LICENSE
 ├─ http-errors@1.8.1
 │  ├─ licenses: MIT
@@ -4225,7 +4232,7 @@
 │  ├─ publisher: Jonathan Ong
 │  ├─ email: me@jongleberry.com
 │  ├─ url: http://jongleberry.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\http-errors
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\http-errors
 │  └─ licenseFile: node_modules\http-errors\LICENSE
 ├─ http-proxy-agent@4.0.1
 │  ├─ licenses: MIT
@@ -4233,7 +4240,7 @@
 │  ├─ publisher: Nathan Rajlich
 │  ├─ email: nathan@tootallnate.net
 │  ├─ url: http://n8.io/
-│  ├─ path: C:\dev\dnn-elements\node_modules\http-proxy-agent
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\http-proxy-agent
 │  └─ licenseFile: node_modules\http-proxy-agent\README.md
 ├─ https-browserify@1.0.0
 │  ├─ licenses: MIT
@@ -4241,7 +4248,7 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\https-browserify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\https-browserify
 │  └─ licenseFile: node_modules\https-browserify\LICENSE
 ├─ https-proxy-agent@5.0.0
 │  ├─ licenses: MIT
@@ -4249,7 +4256,7 @@
 │  ├─ publisher: Nathan Rajlich
 │  ├─ email: nathan@tootallnate.net
 │  ├─ url: http://n8.io/
-│  ├─ path: C:\dev\dnn-elements\node_modules\https-proxy-agent
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\https-proxy-agent
 │  └─ licenseFile: node_modules\https-proxy-agent\README.md
 ├─ human-signals@2.1.0
 │  ├─ licenses: Apache-2.0
@@ -4257,20 +4264,20 @@
 │  ├─ publisher: ehmicky
 │  ├─ email: ehmicky@gmail.com
 │  ├─ url: https://github.com/ehmicky
-│  ├─ path: C:\dev\dnn-elements\node_modules\human-signals
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\human-signals
 │  └─ licenseFile: node_modules\human-signals\LICENSE
 ├─ iconv-lite@0.4.24
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ashtuchkin/iconv-lite
 │  ├─ publisher: Alexander Shtuchkin
 │  ├─ email: ashtuchkin@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\iconv-lite
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\iconv-lite
 │  └─ licenseFile: node_modules\iconv-lite\LICENSE
 ├─ icss-utils@4.1.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/css-modules/icss-utils
 │  ├─ publisher: Glen Maddern
-│  ├─ path: C:\dev\dnn-elements\node_modules\icss-utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\icss-utils
 │  └─ licenseFile: node_modules\icss-utils\LICENSE.md
 ├─ ieee754@1.2.1
 │  ├─ licenses: BSD-3-Clause
@@ -4278,19 +4285,19 @@
 │  ├─ publisher: Feross Aboukhadijeh
 │  ├─ email: feross@feross.org
 │  ├─ url: https://feross.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\ieee754
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ieee754
 │  └─ licenseFile: node_modules\ieee754\LICENSE
 ├─ iferr@0.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/shesek/iferr
 │  ├─ publisher: Nadav Ivgi
-│  ├─ path: C:\dev\dnn-elements\node_modules\iferr
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\iferr
 │  └─ licenseFile: node_modules\iferr\LICENSE
 ├─ ignore@4.0.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/kaelzhang/node-ignore
 │  ├─ publisher: kael
-│  ├─ path: C:\dev\dnn-elements\node_modules\ignore
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ignore
 │  └─ licenseFile: node_modules\ignore\LICENSE-MIT
 ├─ import-fresh@3.3.0
 │  ├─ licenses: MIT
@@ -4298,15 +4305,15 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\import-fresh
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\import-fresh
 │  └─ licenseFile: node_modules\import-fresh\license
-├─ import-local@3.0.3
+├─ import-local@3.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/import-local
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\import-local
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\import-local
 │  └─ licenseFile: node_modules\import-local\license
 ├─ imurmurhash@0.1.4
 │  ├─ licenses: MIT
@@ -4314,7 +4321,7 @@
 │  ├─ publisher: Jens Taylor
 │  ├─ email: jensyt@gmail.com
 │  ├─ url: https://github.com/homebrewing
-│  ├─ path: C:\dev\dnn-elements\node_modules\imurmurhash
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\imurmurhash
 │  └─ licenseFile: node_modules\imurmurhash\README.md
 ├─ indent-string@4.0.0
 │  ├─ licenses: MIT
@@ -4322,7 +4329,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\indent-string
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\indent-string
 │  └─ licenseFile: node_modules\indent-string\license
 ├─ infer-owner@1.0.4
 │  ├─ licenses: ISC
@@ -4330,7 +4337,7 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: https://izs.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\infer-owner
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\infer-owner
 │  └─ licenseFile: node_modules\infer-owner\LICENSE
 ├─ inflight@1.0.6
 │  ├─ licenses: ISC
@@ -4338,24 +4345,24 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\inflight
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\inflight
 │  └─ licenseFile: node_modules\inflight\LICENSE
 ├─ inherits@2.0.4
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/inherits
-│  ├─ path: C:\dev\dnn-elements\node_modules\inherits
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\inherits
 │  └─ licenseFile: node_modules\inherits\LICENSE
 ├─ inline-style-parser@0.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/remarkablemark/inline-style-parser
-│  ├─ path: C:\dev\dnn-elements\node_modules\inline-style-parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\inline-style-parser
 │  └─ licenseFile: node_modules\inline-style-parser\README.md
 ├─ internal-slot@1.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/internal-slot
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\internal-slot
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\internal-slot
 │  └─ licenseFile: node_modules\internal-slot\LICENSE
 ├─ interpret@2.2.0
 │  ├─ licenses: MIT
@@ -4363,28 +4370,28 @@
 │  ├─ publisher: Gulp Team
 │  ├─ email: team@gulpjs.com
 │  ├─ url: http://gulpjs.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\interpret
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\interpret
 │  └─ licenseFile: node_modules\interpret\LICENSE
 ├─ invariant@2.2.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zertosh/invariant
 │  ├─ publisher: Andres Suarez
 │  ├─ email: zertosh@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\invariant
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\invariant
 │  └─ licenseFile: node_modules\invariant\LICENSE
 ├─ ip@1.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/indutny/node-ip
 │  ├─ publisher: Fedor Indutny
 │  ├─ email: fedor@indutny.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\ip
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ip
 │  └─ licenseFile: node_modules\ip\README.md
 ├─ ipaddr.js@1.9.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/whitequark/ipaddr.js
 │  ├─ publisher: whitequark
 │  ├─ email: whitequark@whitequark.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\ipaddr.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ipaddr.js
 │  └─ licenseFile: node_modules\ipaddr.js\LICENSE
 ├─ is-absolute-url@3.0.3
 │  ├─ licenses: MIT
@@ -4392,14 +4399,14 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-absolute-url
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-absolute-url
 │  └─ licenseFile: node_modules\is-absolute-url\license
-├─ is-accessor-descriptor@1.0.0
+├─ is-accessor-descriptor@0.1.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/is-accessor-descriptor
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-accessor-descriptor
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-accessor-descriptor
 │  └─ licenseFile: node_modules\is-accessor-descriptor\LICENSE
 ├─ is-alphabetical@1.0.4
 │  ├─ licenses: MIT
@@ -4407,7 +4414,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-alphabetical
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-alphabetical
 │  └─ licenseFile: node_modules\is-alphabetical\license
 ├─ is-alphanumerical@1.0.4
 │  ├─ licenses: MIT
@@ -4415,7 +4422,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-alphanumerical
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-alphanumerical
 │  └─ licenseFile: node_modules\is-alphanumerical\license
 ├─ is-arguments@1.1.1
 │  ├─ licenses: MIT
@@ -4423,21 +4430,21 @@
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
 │  ├─ url: http://ljharb.codes
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-arguments
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-arguments
 │  └─ licenseFile: node_modules\is-arguments\LICENSE
 ├─ is-arrayish@0.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/qix-/node-is-arrayish
 │  ├─ publisher: Qix
 │  ├─ url: http://github.com/qix-
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-arrayish
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-arrayish
 │  └─ licenseFile: node_modules\is-arrayish\LICENSE
 ├─ is-bigint@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-bigint
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-bigint
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-bigint
 │  └─ licenseFile: node_modules\is-bigint\LICENSE
 ├─ is-binary-path@2.1.0
 │  ├─ licenses: MIT
@@ -4445,22 +4452,22 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-binary-path
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-binary-path
 │  └─ licenseFile: node_modules\is-binary-path\license
 ├─ is-boolean-object@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-boolean-object
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-boolean-object
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-boolean-object
 │  └─ licenseFile: node_modules\is-boolean-object\LICENSE
-├─ is-buffer@2.0.5
+├─ is-buffer@1.1.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/feross/is-buffer
 │  ├─ publisher: Feross Aboukhadijeh
 │  ├─ email: feross@feross.org
-│  ├─ url: https://feross.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-buffer
+│  ├─ url: http://feross.org/
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-buffer
 │  └─ licenseFile: node_modules\is-buffer\LICENSE
 ├─ is-callable@1.2.4
 │  ├─ licenses: MIT
@@ -4468,7 +4475,7 @@
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
 │  ├─ url: http://ljharb.codes
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-callable
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-callable
 │  └─ licenseFile: node_modules\is-callable\LICENSE
 ├─ is-ci@2.0.0
 │  ├─ licenses: MIT
@@ -4476,27 +4483,27 @@
 │  ├─ publisher: Thomas Watson Steen
 │  ├─ email: w@tson.dk
 │  ├─ url: https://twitter.com/wa7son
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-ci
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-ci
 │  └─ licenseFile: node_modules\is-ci\LICENSE
-├─ is-core-module@2.8.0
+├─ is-core-module@2.8.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-core-module
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-core-module
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-core-module
 │  └─ licenseFile: node_modules\is-core-module\LICENSE
-├─ is-data-descriptor@1.0.0
+├─ is-data-descriptor@0.1.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/is-data-descriptor
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-data-descriptor
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-data-descriptor
 │  └─ licenseFile: node_modules\is-data-descriptor\LICENSE
 ├─ is-date-object@1.0.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-date-object
 │  ├─ publisher: Jordan Harband
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-date-object
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-date-object
 │  └─ licenseFile: node_modules\is-date-object\LICENSE
 ├─ is-decimal@1.0.4
 │  ├─ licenses: MIT
@@ -4504,14 +4511,14 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-decimal
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-decimal
 │  └─ licenseFile: node_modules\is-decimal\license
-├─ is-descriptor@1.0.2
+├─ is-descriptor@0.1.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/is-descriptor
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-descriptor
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-descriptor
 │  └─ licenseFile: node_modules\is-descriptor\LICENSE
 ├─ is-docker@2.2.1
 │  ├─ licenses: MIT
@@ -4519,26 +4526,26 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-docker
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-docker
 │  └─ licenseFile: node_modules\is-docker\license
 ├─ is-dom@1.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/npm-dom/is-dom
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-dom
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-dom
 │  └─ licenseFile: node_modules\is-dom\LICENSE
-├─ is-extendable@1.0.1
+├─ is-extendable@0.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/is-extendable
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-extendable
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-extendable
 │  └─ licenseFile: node_modules\is-extendable\LICENSE
 ├─ is-extglob@2.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/is-extglob
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-extglob
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-extglob
 │  └─ licenseFile: node_modules\is-extglob\LICENSE
 ├─ is-fullwidth-code-point@3.0.0
 │  ├─ licenses: MIT
@@ -4546,14 +4553,14 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-fullwidth-code-point
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-fullwidth-code-point
 │  └─ licenseFile: node_modules\is-fullwidth-code-point\license
 ├─ is-function@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/grncdr/js-is-function
 │  ├─ publisher: Stephen Sugden
 │  ├─ email: me@stephensugden.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-function
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-function
 │  └─ licenseFile: node_modules\is-function\LICENSE
 ├─ is-generator-fn@2.1.0
 │  ├─ licenses: MIT
@@ -4561,14 +4568,14 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-generator-fn
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-generator-fn
 │  └─ licenseFile: node_modules\is-generator-fn\license
-├─ is-glob@4.0.1
+├─ is-glob@4.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/micromatch/is-glob
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-glob
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-glob
 │  └─ licenseFile: node_modules\is-glob\LICENSE
 ├─ is-hexadecimal@1.0.4
 │  ├─ licenses: MIT
@@ -4576,42 +4583,42 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-hexadecimal
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-hexadecimal
 │  └─ licenseFile: node_modules\is-hexadecimal\license
 ├─ is-map@2.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-map
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-map
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-map
 │  └─ licenseFile: node_modules\is-map\LICENSE
 ├─ is-negative-zero@2.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-negative-zero
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-negative-zero
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-negative-zero
 │  └─ licenseFile: node_modules\is-negative-zero\LICENSE
 ├─ is-number-object@1.0.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-number-object
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-number-object
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-number-object
 │  └─ licenseFile: node_modules\is-number-object\LICENSE
 ├─ is-number@7.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/is-number
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-number
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-number
 │  └─ licenseFile: node_modules\is-number\LICENSE
 ├─ is-object@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-object
 │  ├─ publisher: Raynos
 │  ├─ email: raynos2@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-object
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-object
 │  └─ licenseFile: node_modules\is-object\LICENSE
 ├─ is-plain-obj@2.1.0
 │  ├─ licenses: MIT
@@ -4619,35 +4626,35 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-plain-obj
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-plain-obj
 │  └─ licenseFile: node_modules\is-plain-obj\license
 ├─ is-plain-object@2.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/is-plain-object
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-plain-object
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-plain-object
 │  └─ licenseFile: node_modules\is-plain-object\LICENSE
 ├─ is-potential-custom-element-name@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/is-potential-custom-element-name
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-potential-custom-element-name
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-potential-custom-element-name
 │  └─ licenseFile: node_modules\is-potential-custom-element-name\LICENSE-MIT.txt
 ├─ is-regex@1.1.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-regex
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-regex
 │  └─ licenseFile: node_modules\is-regex\LICENSE
 ├─ is-set@2.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-set
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-set
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-set
 │  └─ licenseFile: node_modules\is-set\LICENSE
 ├─ is-shared-array-buffer@1.0.1
 │  ├─ licenses: MIT
@@ -4655,29 +4662,29 @@
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
 │  ├─ url: http://ljharb.codes
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-shared-array-buffer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-shared-array-buffer
 │  └─ licenseFile: node_modules\is-shared-array-buffer\LICENSE
-├─ is-stream@2.0.1
+├─ is-stream@1.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/is-stream
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-stream
+│  ├─ url: sindresorhus.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-stream
 │  └─ licenseFile: node_modules\is-stream\license
 ├─ is-string@1.0.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/is-string
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-string
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-string
 │  └─ licenseFile: node_modules\is-string\LICENSE
 ├─ is-symbol@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-symbol
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-symbol
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-symbol
 │  └─ licenseFile: node_modules\is-symbol\LICENSE
 ├─ is-typedarray@1.0.0
 │  ├─ licenses: MIT
@@ -4685,14 +4692,14 @@
 │  ├─ publisher: Hugh Kennedy
 │  ├─ email: hughskennedy@gmail.com
 │  ├─ url: http://hughsk.io/
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-typedarray
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-typedarray
 │  └─ licenseFile: node_modules\is-typedarray\LICENSE.md
 ├─ is-weakref@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-weakref
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-weakref
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-weakref
 │  └─ licenseFile: node_modules\is-weakref\LICENSE
 ├─ is-whitespace-character@1.0.4
 │  ├─ licenses: MIT
@@ -4700,21 +4707,21 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-whitespace-character
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-whitespace-character
 │  └─ licenseFile: node_modules\is-whitespace-character\license
 ├─ is-window@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/gearcase/is-window
 │  ├─ publisher: bubkoo
 │  ├─ email: bubkoo.wy@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-window
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-window
 │  └─ licenseFile: node_modules\is-window\LICENSE
 ├─ is-windows@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/is-windows
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-windows
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-windows
 │  └─ licenseFile: node_modules\is-windows\LICENSE
 ├─ is-word-character@1.0.4
 │  ├─ licenses: MIT
@@ -4722,276 +4729,286 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-word-character
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-word-character
 │  └─ licenseFile: node_modules\is-word-character\license
-├─ is-wsl@2.2.0
+├─ is-wsl@1.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/is-wsl
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\is-wsl
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-wsl
 │  └─ licenseFile: node_modules\is-wsl\license
-├─ isarray@2.0.5
+├─ isarray@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/juliangruber/isarray
 │  ├─ publisher: Julian Gruber
 │  ├─ email: mail@juliangruber.com
 │  ├─ url: http://juliangruber.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\isarray
-│  └─ licenseFile: node_modules\isarray\LICENSE
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\isarray
+│  └─ licenseFile: node_modules\isarray\README.md
 ├─ isexe@2.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/isexe
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\isexe
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\isexe
 │  └─ licenseFile: node_modules\isexe\LICENSE
-├─ isobject@3.0.1
+├─ isobject@4.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/isobject
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\isobject
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\isobject
 │  └─ licenseFile: node_modules\isobject\LICENSE
 ├─ istanbul-lib-coverage@3.2.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/istanbuljs/istanbuljs
 │  ├─ publisher: Krishnan Anantheswaran
 │  ├─ email: kananthmail-github@yahoo.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\istanbul-lib-coverage
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\istanbul-lib-coverage
 │  └─ licenseFile: node_modules\istanbul-lib-coverage\LICENSE
 ├─ istanbul-lib-instrument@5.1.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/istanbuljs/istanbuljs
 │  ├─ publisher: Krishnan Anantheswaran
 │  ├─ email: kananthmail-github@yahoo.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\istanbul-lib-instrument
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\istanbul-lib-instrument
 │  └─ licenseFile: node_modules\istanbul-lib-instrument\LICENSE
 ├─ istanbul-lib-report@3.0.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/istanbuljs/istanbuljs
 │  ├─ publisher: Krishnan Anantheswaran
 │  ├─ email: kananthmail-github@yahoo.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\istanbul-lib-report
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\istanbul-lib-report
 │  └─ licenseFile: node_modules\istanbul-lib-report\LICENSE
 ├─ istanbul-lib-source-maps@4.0.1
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/istanbuljs/istanbuljs
 │  ├─ publisher: Krishnan Anantheswaran
 │  ├─ email: kananthmail-github@yahoo.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\istanbul-lib-source-maps
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\istanbul-lib-source-maps
 │  └─ licenseFile: node_modules\istanbul-lib-source-maps\LICENSE
 ├─ istanbul-reports@3.1.4
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/istanbuljs/istanbuljs
 │  ├─ publisher: Krishnan Anantheswaran
 │  ├─ email: kananthmail-github@yahoo.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\istanbul-reports
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\istanbul-reports
 │  └─ licenseFile: node_modules\istanbul-reports\LICENSE
 ├─ iterate-iterator@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/iterate-iterator
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\iterate-iterator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\iterate-iterator
 │  └─ licenseFile: node_modules\iterate-iterator\LICENSE
 ├─ iterate-value@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/iterate-value
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\iterate-value
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\iterate-value
 │  └─ licenseFile: node_modules\iterate-value\LICENSE
 ├─ jest-changed-files@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-changed-files
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-changed-files
 │  └─ licenseFile: node_modules\jest-changed-files\LICENSE
 ├─ jest-circus@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-circus
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-circus
 │  └─ licenseFile: node_modules\jest-circus\LICENSE
 ├─ jest-cli@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-cli
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-cli
 │  └─ licenseFile: node_modules\jest-cli\LICENSE
 ├─ jest-config@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-config
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-config
 │  └─ licenseFile: node_modules\jest-config\LICENSE
+├─ jest-diff@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-diff
+│  └─ licenseFile: node_modules\jest-diff\LICENSE
 ├─ jest-docblock@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-docblock
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-docblock
 │  └─ licenseFile: node_modules\jest-docblock\LICENSE
 ├─ jest-each@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ publisher: Matt Phillips
 │  ├─ url: mattphillips
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-each
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-each
 │  └─ licenseFile: node_modules\jest-each\LICENSE
 ├─ jest-environment-jsdom@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-environment-jsdom
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-environment-jsdom
 │  └─ licenseFile: node_modules\jest-environment-jsdom\LICENSE
 ├─ jest-environment-node@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-environment-node
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-environment-node
 │  └─ licenseFile: node_modules\jest-environment-node\LICENSE
-├─ jest-haste-map@27.5.1
+├─ jest-get-type@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-haste-map
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-get-type
+│  └─ licenseFile: node_modules\jest-get-type\LICENSE
+├─ jest-haste-map@26.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-haste-map
 │  └─ licenseFile: node_modules\jest-haste-map\LICENSE
 ├─ jest-jasmine2@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-jasmine2
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-jasmine2
 │  └─ licenseFile: node_modules\jest-jasmine2\LICENSE
 ├─ jest-leak-detector@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-leak-detector
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-leak-detector
 │  └─ licenseFile: node_modules\jest-leak-detector\LICENSE
 ├─ jest-matcher-utils@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-matcher-utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-matcher-utils
 │  └─ licenseFile: node_modules\jest-matcher-utils\LICENSE
 ├─ jest-message-util@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-message-util
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-message-util
 │  └─ licenseFile: node_modules\jest-message-util\LICENSE
 ├─ jest-mock@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-mock
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-mock
 │  └─ licenseFile: node_modules\jest-mock\LICENSE
 ├─ jest-pnp-resolver@1.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/arcanis/jest-pnp-resolver
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-pnp-resolver
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-pnp-resolver
 │  └─ licenseFile: node_modules\jest-pnp-resolver\README.md
-├─ jest-regex-util@27.5.1
+├─ jest-regex-util@26.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-regex-util
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-regex-util
 │  └─ licenseFile: node_modules\jest-regex-util\LICENSE
 ├─ jest-resolve-dependencies@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-resolve-dependencies
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-resolve-dependencies
 │  └─ licenseFile: node_modules\jest-resolve-dependencies\LICENSE
 ├─ jest-resolve@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-resolve
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-resolve
 │  └─ licenseFile: node_modules\jest-resolve\LICENSE
 ├─ jest-runner@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-runner
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-runner
 │  └─ licenseFile: node_modules\jest-runner\LICENSE
 ├─ jest-runtime@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-runtime
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-runtime
 │  └─ licenseFile: node_modules\jest-runtime\LICENSE
-├─ jest-serializer@27.5.1
+├─ jest-serializer@26.6.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-serializer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-serializer
 │  └─ licenseFile: node_modules\jest-serializer\LICENSE
 ├─ jest-snapshot@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-snapshot
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-snapshot
 │  └─ licenseFile: node_modules\jest-snapshot\LICENSE
-├─ jest-util@27.5.1
+├─ jest-util@26.6.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-util
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-util
 │  └─ licenseFile: node_modules\jest-util\LICENSE
 ├─ jest-validate@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-validate
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-validate
 │  └─ licenseFile: node_modules\jest-validate\LICENSE
 ├─ jest-watcher@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-watcher
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-watcher
 │  └─ licenseFile: node_modules\jest-watcher\LICENSE
-├─ jest-worker@27.5.1
+├─ jest-worker@26.6.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest-worker
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-worker
 │  └─ licenseFile: node_modules\jest-worker\LICENSE
 ├─ jest@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
-│  ├─ path: C:\dev\dnn-elements\node_modules\jest
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest
 │  └─ licenseFile: node_modules\jest\LICENSE
 ├─ js-string-escape@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/joliss/js-string-escape
 │  ├─ publisher: Jo Liss
 │  ├─ email: joliss42@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\js-string-escape
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\js-string-escape
 │  └─ licenseFile: node_modules\js-string-escape\LICENSE
 ├─ js-tokens@4.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lydell/js-tokens
 │  ├─ publisher: Simon Lydell
-│  ├─ path: C:\dev\dnn-elements\node_modules\js-tokens
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\js-tokens
 │  └─ licenseFile: node_modules\js-tokens\LICENSE
-├─ js-yaml@3.13.1
+├─ js-yaml@3.14.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/nodeca/js-yaml
 │  ├─ publisher: Vladimir Zapparov
 │  ├─ email: dervus.grim@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\js-yaml
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\js-yaml
 │  └─ licenseFile: node_modules\js-yaml\LICENSE
 ├─ jsdom@16.7.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jsdom/jsdom
-│  ├─ path: C:\dev\dnn-elements\node_modules\jsdom
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jsdom
 │  └─ licenseFile: node_modules\jsdom\LICENSE.txt
 ├─ jsesc@2.5.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/jsesc
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\jsesc
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jsesc
 │  └─ licenseFile: node_modules\jsesc\LICENSE-MIT.txt
 ├─ json-parse-better-errors@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zkat/json-parse-better-errors
 │  ├─ publisher: Kat Marchán
 │  ├─ email: kzm@zkat.tech
-│  ├─ path: C:\dev\dnn-elements\node_modules\json-parse-better-errors
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\json-parse-better-errors
 │  └─ licenseFile: node_modules\json-parse-better-errors\LICENSE.md
 ├─ json-parse-even-better-errors@2.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/npm/json-parse-even-better-errors
 │  ├─ publisher: Kat Marchán
 │  ├─ email: kzm@zkat.tech
-│  ├─ path: C:\dev\dnn-elements\node_modules\json-parse-even-better-errors
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\json-parse-even-better-errors
 │  └─ licenseFile: node_modules\json-parse-even-better-errors\LICENSE.md
 ├─ json-schema-traverse@0.4.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/epoberezkin/json-schema-traverse
 │  ├─ publisher: Evgeny Poberezkin
-│  ├─ path: C:\dev\dnn-elements\node_modules\json-schema-traverse
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\json-schema-traverse
 │  └─ licenseFile: node_modules\json-schema-traverse\LICENSE
 ├─ json-stable-stringify-without-jsonify@1.0.1
 │  ├─ licenses: MIT
@@ -4999,27 +5016,27 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\json-stable-stringify-without-jsonify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\json-stable-stringify-without-jsonify
 │  └─ licenseFile: node_modules\json-stable-stringify-without-jsonify\LICENSE
 ├─ json5@2.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/json5/json5
 │  ├─ publisher: Aseem Kishore
 │  ├─ email: aseem.kishore@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\json5
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\json5
 │  └─ licenseFile: node_modules\json5\LICENSE.md
-├─ jsonfile@6.1.0
+├─ jsonfile@2.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jprichardson/node-jsonfile
 │  ├─ publisher: JP Richardson
 │  ├─ email: jprichardson@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\jsonfile
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jsonfile
 │  └─ licenseFile: node_modules\jsonfile\LICENSE
 ├─ jsx-ast-utils@3.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jsx-eslint/jsx-ast-utils
 │  ├─ publisher: Ethan Cohen
-│  ├─ path: C:\dev\dnn-elements\node_modules\jsx-ast-utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jsx-ast-utils
 │  └─ licenseFile: node_modules\jsx-ast-utils\LICENSE.md
 ├─ junk@3.1.0
 │  ├─ licenses: MIT
@@ -5027,20 +5044,20 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\junk
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\junk
 │  └─ licenseFile: node_modules\junk\license
 ├─ kind-of@6.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/kind-of
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\kind-of
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\kind-of
 │  └─ licenseFile: node_modules\kind-of\LICENSE
 ├─ klaw@1.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jprichardson/node-klaw
 │  ├─ publisher: JP Richardson
-│  ├─ path: C:\dev\dnn-elements\node_modules\klaw
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\klaw
 │  └─ licenseFile: node_modules\klaw\LICENSE
 ├─ kleur@3.0.3
 │  ├─ licenses: MIT
@@ -5048,7 +5065,7 @@
 │  ├─ publisher: Luke Edwards
 │  ├─ email: luke.edwards05@gmail.com
 │  ├─ url: lukeed.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\kleur
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\kleur
 │  └─ licenseFile: node_modules\kleur\license
 ├─ klona@2.0.5
 │  ├─ licenses: MIT
@@ -5056,13 +5073,13 @@
 │  ├─ publisher: Luke Edwards
 │  ├─ email: luke.edwards05@gmail.com
 │  ├─ url: https://lukeed.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\klona
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\klona
 │  └─ licenseFile: node_modules\klona\license
 ├─ lazy-universal-dotenv@3.0.1
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/storybooks/lazy-universal-dotenv
 │  ├─ publisher: Storybook Team
-│  ├─ path: C:\dev\dnn-elements\node_modules\lazy-universal-dotenv
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lazy-universal-dotenv
 │  └─ licenseFile: node_modules\lazy-universal-dotenv\license
 ├─ leven@3.1.0
 │  ├─ licenses: MIT
@@ -5070,34 +5087,34 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\leven
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\leven
 │  └─ licenseFile: node_modules\leven\license
 ├─ levn@0.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/gkz/levn
 │  ├─ publisher: George Zahariev
 │  ├─ email: z@georgezahariev.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\levn
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\levn
 │  └─ licenseFile: node_modules\levn\LICENSE
 ├─ license-checker@25.0.1
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/davglass/license-checker
 │  ├─ publisher: Dav Glass
 │  ├─ email: davglass@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\license-checker
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\license-checker
 │  └─ licenseFile: node_modules\license-checker\LICENSE
-├─ lines-and-columns@1.1.6
+├─ lines-and-columns@1.2.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/eventualbuddha/lines-and-columns
 │  ├─ publisher: Brian Donovan
-│  ├─ email: me@brian-donovan.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\lines-and-columns
+│  ├─ email: brian@donovans.cc
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lines-and-columns
 │  └─ licenseFile: node_modules\lines-and-columns\LICENSE
-├─ lit-html@2.2.0
+├─ lit-html@2.2.1
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/lit/lit
 │  ├─ publisher: Google LLC
-│  ├─ path: C:\dev\dnn-elements\node_modules\lit-html
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lit-html
 │  └─ licenseFile: node_modules\lit-html\LICENSE
 ├─ load-json-file@4.0.0
 │  ├─ licenses: MIT
@@ -5105,19 +5122,19 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\load-json-file
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\load-json-file
 │  └─ licenseFile: node_modules\load-json-file\license
 ├─ loader-runner@2.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/loader-runner
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\loader-runner
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\loader-runner
 │  └─ licenseFile: node_modules\loader-runner\LICENSE
-├─ loader-utils@2.0.2
+├─ loader-utils@1.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/loader-utils
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\loader-utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\loader-utils
 │  └─ licenseFile: node_modules\loader-utils\LICENSE
 ├─ locate-path@5.0.0
 │  ├─ licenses: MIT
@@ -5125,7 +5142,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\locate-path
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\locate-path
 │  └─ licenseFile: node_modules\locate-path\license
 ├─ lodash.debounce@4.0.8
 │  ├─ licenses: MIT
@@ -5133,7 +5150,7 @@
 │  ├─ publisher: John-David Dalton
 │  ├─ email: john.david.dalton@gmail.com
 │  ├─ url: http://allyoucanleet.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\lodash.debounce
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lodash.debounce
 │  └─ licenseFile: node_modules\lodash.debounce\LICENSE
 ├─ lodash.memoize@4.1.2
 │  ├─ licenses: MIT
@@ -5141,14 +5158,14 @@
 │  ├─ publisher: John-David Dalton
 │  ├─ email: john.david.dalton@gmail.com
 │  ├─ url: http://allyoucanleet.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\lodash.memoize
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lodash.memoize
 │  └─ licenseFile: node_modules\lodash.memoize\LICENSE
 ├─ lodash.merge@4.6.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lodash/lodash
 │  ├─ publisher: John-David Dalton
 │  ├─ email: john.david.dalton@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\lodash.merge
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lodash.merge
 │  └─ licenseFile: node_modules\lodash.merge\LICENSE
 ├─ lodash.throttle@4.1.1
 │  ├─ licenses: MIT
@@ -5156,7 +5173,7 @@
 │  ├─ publisher: John-David Dalton
 │  ├─ email: john.david.dalton@gmail.com
 │  ├─ url: http://allyoucanleet.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\lodash.throttle
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lodash.throttle
 │  └─ licenseFile: node_modules\lodash.throttle\LICENSE
 ├─ lodash.truncate@4.4.2
 │  ├─ licenses: MIT
@@ -5164,7 +5181,7 @@
 │  ├─ publisher: John-David Dalton
 │  ├─ email: john.david.dalton@gmail.com
 │  ├─ url: http://allyoucanleet.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\lodash.truncate
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lodash.truncate
 │  └─ licenseFile: node_modules\lodash.truncate\LICENSE
 ├─ lodash.uniq@4.5.0
 │  ├─ licenses: MIT
@@ -5172,21 +5189,21 @@
 │  ├─ publisher: John-David Dalton
 │  ├─ email: john.david.dalton@gmail.com
 │  ├─ url: http://allyoucanleet.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\lodash.uniq
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lodash.uniq
 │  └─ licenseFile: node_modules\lodash.uniq\LICENSE
 ├─ lodash@4.17.21
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lodash/lodash
 │  ├─ publisher: John-David Dalton
 │  ├─ email: john.david.dalton@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\lodash
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lodash
 │  └─ licenseFile: node_modules\lodash\LICENSE
 ├─ loose-envify@1.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zertosh/loose-envify
 │  ├─ publisher: Andres Suarez
 │  ├─ email: zertosh@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\loose-envify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\loose-envify
 │  └─ licenseFile: node_modules\loose-envify\LICENSE
 ├─ lower-case@2.0.2
 │  ├─ licenses: MIT
@@ -5194,7 +5211,7 @@
 │  ├─ publisher: Blake Embrey
 │  ├─ email: hello@blakeembrey.com
 │  ├─ url: http://blakeembrey.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\lower-case
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lower-case
 │  └─ licenseFile: node_modules\lower-case\LICENSE
 ├─ lowlight@1.20.0
 │  ├─ licenses: MIT
@@ -5202,50 +5219,50 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\lowlight
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lowlight
 │  └─ licenseFile: node_modules\lowlight\license
 ├─ lru-cache@6.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/node-lru-cache
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\lru-cache
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\lru-cache
 │  └─ licenseFile: node_modules\lru-cache\LICENSE
-├─ make-dir@3.1.0
+├─ make-dir@2.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/make-dir
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\make-dir
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\make-dir
 │  └─ licenseFile: node_modules\make-dir\license
 ├─ makeerror@1.0.12
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/daaku/nodejs-makeerror
 │  ├─ publisher: Naitik Shah
 │  ├─ email: n@daaku.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\makeerror
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\makeerror
 │  └─ licenseFile: node_modules\makeerror\license
 ├─ map-cache@0.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/map-cache
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\map-cache
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\map-cache
 │  └─ licenseFile: node_modules\map-cache\LICENSE
 ├─ map-or-similar@1.5.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/thinkloop/map-or-similar
 │  ├─ publisher: Baz
 │  ├─ email: baz@thinkloop.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\map-or-similar
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\map-or-similar
 │  └─ licenseFile: node_modules\map-or-similar\LICENSE
 ├─ map-visit@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/map-visit
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\map-visit
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\map-visit
 │  └─ licenseFile: node_modules\map-visit\LICENSE
 ├─ markdown-escapes@1.0.4
 │  ├─ licenses: MIT
@@ -5253,14 +5270,14 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\markdown-escapes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\markdown-escapes
 │  └─ licenseFile: node_modules\markdown-escapes\license
 ├─ markdown-to-jsx@7.1.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/probablyup/markdown-to-jsx
 │  ├─ publisher: Evan Jacobs
 │  ├─ email: probablyup@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\markdown-to-jsx
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\markdown-to-jsx
 │  └─ licenseFile: node_modules\markdown-to-jsx\LICENSE
 ├─ md5.js@1.3.5
 │  ├─ licenses: MIT
@@ -5268,14 +5285,14 @@
 │  ├─ publisher: Kirill Fomichev
 │  ├─ email: fanatid@ya.ru
 │  ├─ url: https://github.com/fanatid
-│  ├─ path: C:\dev\dnn-elements\node_modules\md5.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\md5.js
 │  └─ licenseFile: node_modules\md5.js\LICENSE
 ├─ mdast-squeeze-paragraphs@4.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/syntax-tree/mdast-squeeze-paragraphs
 │  ├─ publisher: Eugene Sharygin
 │  ├─ email: eush77@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\mdast-squeeze-paragraphs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mdast-squeeze-paragraphs
 │  └─ licenseFile: node_modules\mdast-squeeze-paragraphs\license
 ├─ mdast-util-definitions@4.0.0
 │  ├─ licenses: MIT
@@ -5283,7 +5300,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\mdast-util-definitions
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mdast-util-definitions
 │  └─ licenseFile: node_modules\mdast-util-definitions\license
 ├─ mdast-util-to-hast@10.0.1
 │  ├─ licenses: MIT
@@ -5291,7 +5308,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\mdast-util-to-hast
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mdast-util-to-hast
 │  └─ licenseFile: node_modules\mdast-util-to-hast\license
 ├─ mdast-util-to-string@1.1.0
 │  ├─ licenses: MIT
@@ -5299,44 +5316,44 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\mdast-util-to-string
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mdast-util-to-string
 │  └─ licenseFile: node_modules\mdast-util-to-string\license
 ├─ mdurl@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/markdown-it/mdurl
-│  ├─ path: C:\dev\dnn-elements\node_modules\mdurl
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mdurl
 │  └─ licenseFile: node_modules\mdurl\LICENSE
 ├─ media-typer@0.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/media-typer
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\media-typer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\media-typer
 │  └─ licenseFile: node_modules\media-typer\LICENSE
 ├─ memfs@3.4.1
 │  ├─ licenses: Unlicense
 │  ├─ repository: https://github.com/streamich/memfs
-│  ├─ path: C:\dev\dnn-elements\node_modules\memfs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\memfs
 │  └─ licenseFile: node_modules\memfs\LICENSE
 ├─ memoizerific@1.11.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/thinkloop/memoizerific
 │  ├─ publisher: Baz
 │  ├─ email: baz@thinkloop.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\memoizerific
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\memoizerific
 │  └─ licenseFile: node_modules\memoizerific\LICENSE
 ├─ memory-fs@0.4.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/memory-fs
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\memory-fs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\memory-fs
 │  └─ licenseFile: node_modules\memory-fs\README.md
 ├─ memorystream@0.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/JSBizon/node-memorystream
 │  ├─ publisher: Dmitry Nizovtsev
 │  ├─ url: https://github.com/JSBizon
-│  ├─ path: C:\dev\dnn-elements\node_modules\memorystream
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\memorystream
 │  └─ licenseFile: node_modules\memorystream\LICENSE
 ├─ merge-descriptors@1.0.1
 │  ├─ licenses: MIT
@@ -5344,24 +5361,24 @@
 │  ├─ publisher: Jonathan Ong
 │  ├─ email: me@jongleberry.com
 │  ├─ url: http://jongleberry.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\merge-descriptors
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\merge-descriptors
 │  └─ licenseFile: node_modules\merge-descriptors\LICENSE
 ├─ merge-stream@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/grncdr/merge-stream
 │  ├─ publisher: Stephen Sugden
 │  ├─ email: me@stephensugden.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\merge-stream
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\merge-stream
 │  └─ licenseFile: node_modules\merge-stream\LICENSE
 ├─ merge2@1.4.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/teambition/merge2
-│  ├─ path: C:\dev\dnn-elements\node_modules\merge2
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\merge2
 │  └─ licenseFile: node_modules\merge2\LICENSE
 ├─ methods@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/methods
-│  ├─ path: C:\dev\dnn-elements\node_modules\methods
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\methods
 │  └─ licenseFile: node_modules\methods\LICENSE
 ├─ microevent.ts@0.1.1
 │  ├─ licenses: MIT
@@ -5369,31 +5386,31 @@
 │  ├─ publisher: Christian Speckner
 │  ├─ email: cnspeckn@googlemail.com
 │  ├─ url: https://github.com/DirtyHairy/
-│  ├─ path: C:\dev\dnn-elements\node_modules\microevent.ts
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\microevent.ts
 │  └─ licenseFile: node_modules\microevent.ts\LICENSE
-├─ micromatch@4.0.4
+├─ micromatch@3.1.10
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/micromatch/micromatch
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\micromatch
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\micromatch
 │  └─ licenseFile: node_modules\micromatch\LICENSE
 ├─ miller-rabin@4.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/indutny/miller-rabin
 │  ├─ publisher: Fedor Indutny
 │  ├─ email: fedor@indutny.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\miller-rabin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\miller-rabin
 │  └─ licenseFile: node_modules\miller-rabin\README.md
-├─ mime-db@1.51.0
+├─ mime-db@1.52.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/mime-db
-│  ├─ path: C:\dev\dnn-elements\node_modules\mime-db
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mime-db
 │  └─ licenseFile: node_modules\mime-db\LICENSE
-├─ mime-types@2.1.34
+├─ mime-types@2.1.35
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/mime-types
-│  ├─ path: C:\dev\dnn-elements\node_modules\mime-types
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mime-types
 │  └─ licenseFile: node_modules\mime-types\LICENSE
 ├─ mime@1.6.0
 │  ├─ licenses: MIT
@@ -5401,7 +5418,7 @@
 │  ├─ publisher: Robert Kieffer
 │  ├─ email: robert@broofa.com
 │  ├─ url: http://github.com/broofa
-│  ├─ path: C:\dev\dnn-elements\node_modules\mime
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mime
 │  └─ licenseFile: node_modules\mime\LICENSE
 ├─ mimic-fn@2.1.0
 │  ├─ licenses: MIT
@@ -5409,26 +5426,26 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\mimic-fn
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mimic-fn
 │  └─ licenseFile: node_modules\mimic-fn\license
 ├─ min-document@2.19.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Raynos/min-document
 │  ├─ publisher: Raynos
 │  ├─ email: raynos2@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\min-document
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\min-document
 │  └─ licenseFile: node_modules\min-document\LICENCE
 ├─ minimalistic-assert@1.0.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/calvinmetcalf/minimalistic-assert
-│  ├─ path: C:\dev\dnn-elements\node_modules\minimalistic-assert
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\minimalistic-assert
 │  └─ licenseFile: node_modules\minimalistic-assert\LICENSE
 ├─ minimalistic-crypto-utils@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/indutny/minimalistic-crypto-utils
 │  ├─ publisher: Fedor Indutny
 │  ├─ email: fedor@indutny.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\minimalistic-crypto-utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\minimalistic-crypto-utils
 │  └─ licenseFile: node_modules\minimalistic-crypto-utils\README.md
 ├─ minimatch@3.1.2
 │  ├─ licenses: ISC
@@ -5436,7 +5453,7 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\minimatch
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\minimatch
 │  └─ licenseFile: node_modules\minimatch\LICENSE
 ├─ minimist@1.2.5
 │  ├─ licenses: MIT
@@ -5444,14 +5461,14 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\minimist
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\minimist
 │  └─ licenseFile: node_modules\minimist\LICENSE
 ├─ minipass-collect@1.0.2
 │  ├─ licenses: ISC
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: https://izs.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\minipass-collect
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\minipass-collect
 │  └─ licenseFile: node_modules\minipass-collect\LICENSE
 ├─ minipass-flush@1.0.5
 │  ├─ licenses: ISC
@@ -5459,14 +5476,14 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: https://izs.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\minipass-flush
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\minipass-flush
 │  └─ licenseFile: node_modules\minipass-flush\LICENSE
 ├─ minipass-pipeline@1.2.4
 │  ├─ licenses: ISC
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: https://izs.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\minipass-pipeline
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\minipass-pipeline
 │  └─ licenseFile: node_modules\minipass-pipeline\LICENSE
 ├─ minipass@3.1.6
 │  ├─ licenses: ISC
@@ -5474,7 +5491,7 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\minipass
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\minipass
 │  └─ licenseFile: node_modules\minipass\LICENSE
 ├─ minizlib@2.1.2
 │  ├─ licenses: MIT
@@ -5482,27 +5499,27 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\minizlib
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\minizlib
 │  └─ licenseFile: node_modules\minizlib\LICENSE
 ├─ mississippi@3.0.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/maxogden/mississippi
 │  ├─ publisher: max ogden
-│  ├─ path: C:\dev\dnn-elements\node_modules\mississippi
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mississippi
 │  └─ licenseFile: node_modules\mississippi\license
 ├─ mixin-deep@1.3.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/mixin-deep
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\mixin-deep
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mixin-deep
 │  └─ licenseFile: node_modules\mixin-deep\LICENSE
 ├─ mkdirp-classic@0.5.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/mkdirp-classic
 │  ├─ publisher: Mathias Buus
 │  ├─ url: @mafintosh
-│  ├─ path: C:\dev\dnn-elements\node_modules\mkdirp-classic
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mkdirp-classic
 │  └─ licenseFile: node_modules\mkdirp-classic\LICENSE
 ├─ mkdirp@0.5.5
 │  ├─ licenses: MIT
@@ -5510,7 +5527,7 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\mkdirp
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mkdirp
 │  └─ licenseFile: node_modules\mkdirp\LICENSE
 ├─ move-concurrently@1.0.1
 │  ├─ licenses: ISC
@@ -5518,55 +5535,55 @@
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
 │  ├─ url: http://re-becca.org/
-│  ├─ path: C:\dev\dnn-elements\node_modules\move-concurrently
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\move-concurrently
 │  └─ licenseFile: node_modules\move-concurrently\LICENSE
 ├─ ms@2.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zeit/ms
-│  ├─ path: C:\dev\dnn-elements\node_modules\ms
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ms
 │  └─ licenseFile: node_modules\ms\license.md
 ├─ nanoid@3.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ai/nanoid
 │  ├─ publisher: Andrey Sitnik
 │  ├─ email: andrey@sitnik.ru
-│  ├─ path: C:\dev\dnn-elements\node_modules\nanoid
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\nanoid
 │  └─ licenseFile: node_modules\nanoid\LICENSE
 ├─ nanomatch@1.2.13
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/micromatch/nanomatch
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\nanomatch
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\nanomatch
 │  └─ licenseFile: node_modules\nanomatch\LICENSE
 ├─ natural-compare@1.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/litejs/natural-compare-lite
 │  ├─ publisher: Lauri Rooden
 │  ├─ url: https://github.com/litejs/natural-compare-lite
-│  ├─ path: C:\dev\dnn-elements\node_modules\natural-compare
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\natural-compare
 │  └─ licenseFile: node_modules\natural-compare\README.md
 ├─ negotiator@0.6.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/negotiator
-│  ├─ path: C:\dev\dnn-elements\node_modules\negotiator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\negotiator
 │  └─ licenseFile: node_modules\negotiator\LICENSE
 ├─ neo-async@2.6.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/suguru03/neo-async
-│  ├─ path: C:\dev\dnn-elements\node_modules\neo-async
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\neo-async
 │  └─ licenseFile: node_modules\neo-async\LICENSE
 ├─ nested-error-stacks@2.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mdlavin/nested-error-stacks
 │  ├─ publisher: Matt Lavin
 │  ├─ email: matt.lavin@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\nested-error-stacks
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\nested-error-stacks
 │  └─ licenseFile: node_modules\nested-error-stacks\LICENSE
 ├─ nice-try@1.0.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/electerious/nice-try
-│  ├─ path: C:\dev\dnn-elements\node_modules\nice-try
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\nice-try
 │  └─ licenseFile: node_modules\nice-try\LICENSE
 ├─ no-case@3.0.4
 │  ├─ licenses: MIT
@@ -5574,33 +5591,33 @@
 │  ├─ publisher: Blake Embrey
 │  ├─ email: hello@blakeembrey.com
 │  ├─ url: http://blakeembrey.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\no-case
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\no-case
 │  └─ licenseFile: node_modules\no-case\LICENSE
 ├─ node-fetch@2.6.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/bitinn/node-fetch
 │  ├─ publisher: David Frank
-│  ├─ path: C:\dev\dnn-elements\node_modules\node-fetch
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\node-fetch
 │  └─ licenseFile: node_modules\node-fetch\LICENSE.md
 ├─ node-int64@0.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/broofa/node-int64
 │  ├─ publisher: Robert Kieffer
 │  ├─ email: robert@broofa.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\node-int64
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\node-int64
 │  └─ licenseFile: node_modules\node-int64\LICENSE
 ├─ node-libs-browser@2.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/node-libs-browser
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\node-libs-browser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\node-libs-browser
 │  └─ licenseFile: node_modules\node-libs-browser\LICENSE
 ├─ node-releases@2.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/chicoxyzzy/node-releases
 │  ├─ publisher: Sergey Rubanov
 │  ├─ email: chi187@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\node-releases
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\node-releases
 │  └─ licenseFile: node_modules\node-releases\LICENSE
 ├─ nopt@4.0.3
 │  ├─ licenses: ISC
@@ -5608,21 +5625,21 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\nopt
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\nopt
 │  └─ licenseFile: node_modules\nopt\LICENSE
 ├─ normalize-package-data@2.5.0
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/npm/normalize-package-data
 │  ├─ publisher: Meryn Stol
 │  ├─ email: merynstol@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\normalize-package-data
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\normalize-package-data
 │  └─ licenseFile: node_modules\normalize-package-data\LICENSE
 ├─ normalize-path@3.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/normalize-path
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\normalize-path
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\normalize-path
 │  └─ licenseFile: node_modules\normalize-path\LICENSE
 ├─ normalize-range@0.1.2
 │  ├─ licenses: MIT
@@ -5630,7 +5647,7 @@
 │  ├─ publisher: James Talmage
 │  ├─ email: james@talmage.io
 │  ├─ url: github.com/jamestalmage
-│  ├─ path: C:\dev\dnn-elements\node_modules\normalize-range
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\normalize-range
 │  └─ licenseFile: node_modules\normalize-range\license
 ├─ npm-normalize-package-bin@1.0.1
 │  ├─ licenses: ISC
@@ -5638,21 +5655,21 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: https://izs.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\npm-normalize-package-bin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\npm-normalize-package-bin
 │  └─ licenseFile: node_modules\npm-normalize-package-bin\LICENSE
 ├─ npm-run-all@4.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mysticatea/npm-run-all
 │  ├─ publisher: Toru Nagashima
-│  ├─ path: C:\dev\dnn-elements\node_modules\npm-run-all
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\npm-run-all
 │  └─ licenseFile: node_modules\npm-run-all\LICENSE
-├─ npm-run-path@4.0.1
+├─ npm-run-path@2.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/npm-run-path
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\npm-run-path
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\npm-run-path
 │  └─ licenseFile: node_modules\npm-run-path\license
 ├─ npmlog@5.0.1
 │  ├─ licenses: ISC
@@ -5660,14 +5677,14 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\npmlog
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\npmlog
 │  └─ licenseFile: node_modules\npmlog\LICENSE
 ├─ nth-check@2.0.1
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/fb55/nth-check
 │  ├─ publisher: Felix Boehm
 │  ├─ email: me@feedic.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\nth-check
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\nth-check
 │  └─ licenseFile: node_modules\nth-check\LICENSE
 ├─ num2fraction@1.2.2
 │  ├─ licenses: MIT
@@ -5675,7 +5692,7 @@
 │  ├─ publisher: yisi
 │  ├─ email: yiorsi@gmail.com
 │  ├─ url: http://iyunlu.com/view
-│  ├─ path: C:\dev\dnn-elements\node_modules\num2fraction
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\num2fraction
 │  └─ licenseFile: node_modules\num2fraction\LICENSE
 ├─ nwsapi@2.2.0
 │  ├─ licenses: MIT
@@ -5683,7 +5700,7 @@
 │  ├─ publisher: Diego Perini
 │  ├─ email: diego.perini@gmail.com
 │  ├─ url: http://www.iport.it/
-│  ├─ path: C:\dev\dnn-elements\node_modules\nwsapi
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\nwsapi
 │  └─ licenseFile: node_modules\nwsapi\LICENSE
 ├─ object-assign@4.1.1
 │  ├─ licenses: MIT
@@ -5691,14 +5708,14 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\object-assign
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object-assign
 │  └─ licenseFile: node_modules\object-assign\license
 ├─ object-copy@0.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/object-copy
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\object-copy
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object-copy
 │  └─ licenseFile: node_modules\object-copy\LICENSE
 ├─ object-inspect@1.12.0
 │  ├─ licenses: MIT
@@ -5706,13 +5723,13 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\object-inspect
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object-inspect
 │  └─ licenseFile: node_modules\object-inspect\LICENSE
 ├─ object-is@1.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/object-is
 │  ├─ publisher: Jordan Harband
-│  ├─ path: C:\dev\dnn-elements\node_modules\object-is
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object-is
 │  └─ licenseFile: node_modules\object-is\LICENSE
 ├─ object-keys@1.1.1
 │  ├─ licenses: MIT
@@ -5720,73 +5737,73 @@
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
 │  ├─ url: http://ljharb.codes
-│  ├─ path: C:\dev\dnn-elements\node_modules\object-keys
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object-keys
 │  └─ licenseFile: node_modules\object-keys\LICENSE
 ├─ object-visit@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/object-visit
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\object-visit
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object-visit
 │  └─ licenseFile: node_modules\object-visit\LICENSE
 ├─ object.assign@4.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/object.assign
 │  ├─ publisher: Jordan Harband
-│  ├─ path: C:\dev\dnn-elements\node_modules\object.assign
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object.assign
 │  └─ licenseFile: node_modules\object.assign\LICENSE
 ├─ object.entries@1.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/Object.entries
 │  ├─ publisher: Jordan Harband
-│  ├─ path: C:\dev\dnn-elements\node_modules\object.entries
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object.entries
 │  └─ licenseFile: node_modules\object.entries\LICENSE
 ├─ object.fromentries@2.0.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/Object.fromEntries
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\object.fromentries
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object.fromentries
 │  └─ licenseFile: node_modules\object.fromentries\LICENSE
 ├─ object.getownpropertydescriptors@2.1.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/object.getownpropertydescriptors
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\object.getownpropertydescriptors
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object.getownpropertydescriptors
 │  └─ licenseFile: node_modules\object.getownpropertydescriptors\LICENSE
 ├─ object.hasown@1.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/Object.hasOwn
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\object.hasown
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object.hasown
 │  └─ licenseFile: node_modules\object.hasown\LICENSE
 ├─ object.pick@1.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/object.pick
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\object.pick
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object.pick
 │  └─ licenseFile: node_modules\object.pick\LICENSE
 ├─ object.values@1.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/Object.values
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\object.values
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object.values
 │  └─ licenseFile: node_modules\object.values\LICENSE
 ├─ on-finished@2.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/on-finished
-│  ├─ path: C:\dev\dnn-elements\node_modules\on-finished
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\on-finished
 │  └─ licenseFile: node_modules\on-finished\LICENSE
 ├─ on-headers@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/on-headers
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\on-headers
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\on-headers
 │  └─ licenseFile: node_modules\on-headers\LICENSE
 ├─ once@1.4.0
 │  ├─ licenses: ISC
@@ -5794,7 +5811,7 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\once
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\once
 │  └─ licenseFile: node_modules\once\LICENSE
 ├─ onetime@5.1.2
 │  ├─ licenses: MIT
@@ -5802,7 +5819,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\onetime
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\onetime
 │  └─ licenseFile: node_modules\onetime\license
 ├─ open@7.4.2
 │  ├─ licenses: MIT
@@ -5810,21 +5827,21 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\open
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\open
 │  └─ licenseFile: node_modules\open\license
 ├─ optionator@0.8.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/gkz/optionator
 │  ├─ publisher: George Zahariev
 │  ├─ email: z@georgezahariev.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\optionator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\optionator
 │  └─ licenseFile: node_modules\optionator\LICENSE
 ├─ os-browserify@0.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/CoderPuppy/os-browserify
 │  ├─ publisher: CoderPuppy
 │  ├─ email: coderpup@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\os-browserify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\os-browserify
 │  └─ licenseFile: node_modules\os-browserify\LICENSE
 ├─ os-homedir@1.0.2
 │  ├─ licenses: MIT
@@ -5832,7 +5849,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\os-homedir
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\os-homedir
 │  └─ licenseFile: node_modules\os-homedir\license
 ├─ os-tmpdir@1.0.2
 │  ├─ licenses: MIT
@@ -5840,7 +5857,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\os-tmpdir
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\os-tmpdir
 │  └─ licenseFile: node_modules\os-tmpdir\license
 ├─ osenv@0.1.5
 │  ├─ licenses: ISC
@@ -5848,13 +5865,13 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\osenv
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\osenv
 │  └─ licenseFile: node_modules\osenv\LICENSE
 ├─ overlayscrollbars@1.13.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/KingSora/OverlayScrollbars
 │  ├─ publisher: KingSora | Rene Haas
-│  ├─ path: C:\dev\dnn-elements\node_modules\overlayscrollbars
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\overlayscrollbars
 │  └─ licenseFile: node_modules\overlayscrollbars\LICENSE
 ├─ p-all@2.1.0
 │  ├─ licenses: MIT
@@ -5862,7 +5879,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\p-all
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\p-all
 │  └─ licenseFile: node_modules\p-all\license
 ├─ p-event@4.2.0
 │  ├─ licenses: MIT
@@ -5870,7 +5887,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\p-event
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\p-event
 │  └─ licenseFile: node_modules\p-event\license
 ├─ p-filter@2.1.0
 │  ├─ licenses: MIT
@@ -5878,7 +5895,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\p-filter
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\p-filter
 │  └─ licenseFile: node_modules\p-filter\license
 ├─ p-finally@1.0.0
 │  ├─ licenses: MIT
@@ -5886,7 +5903,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\p-finally
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\p-finally
 │  └─ licenseFile: node_modules\p-finally\license
 ├─ p-limit@2.3.0
 │  ├─ licenses: MIT
@@ -5894,7 +5911,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\p-limit
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\p-limit
 │  └─ licenseFile: node_modules\p-limit\license
 ├─ p-locate@4.1.0
 │  ├─ licenses: MIT
@@ -5902,15 +5919,15 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\p-locate
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\p-locate
 │  └─ licenseFile: node_modules\p-locate\license
-├─ p-map@3.0.0
+├─ p-map@4.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/p-map
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\p-map
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\p-map
 │  └─ licenseFile: node_modules\p-map\license
 ├─ p-timeout@3.2.0
 │  ├─ licenses: MIT
@@ -5918,7 +5935,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\p-timeout
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\p-timeout
 │  └─ licenseFile: node_modules\p-timeout\license
 ├─ p-try@2.2.0
 │  ├─ licenses: MIT
@@ -5926,19 +5943,19 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\p-try
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\p-try
 │  └─ licenseFile: node_modules\p-try\license
 ├─ pako@1.0.11
 │  ├─ licenses: (MIT AND Zlib)
 │  ├─ repository: https://github.com/nodeca/pako
-│  ├─ path: C:\dev\dnn-elements\node_modules\pako
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pako
 │  └─ licenseFile: node_modules\pako\LICENSE
 ├─ parallel-transform@1.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/parallel-transform
 │  ├─ publisher: Mathias Buus Madsen
 │  ├─ email: mathiasbuus@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\parallel-transform
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\parallel-transform
 │  └─ licenseFile: node_modules\parallel-transform\LICENSE
 ├─ param-case@3.0.4
 │  ├─ licenses: MIT
@@ -5946,7 +5963,7 @@
 │  ├─ publisher: Blake Embrey
 │  ├─ email: hello@blakeembrey.com
 │  ├─ url: http://blakeembrey.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\param-case
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\param-case
 │  └─ licenseFile: node_modules\param-case\LICENSE
 ├─ parent-module@1.0.1
 │  ├─ licenses: MIT
@@ -5954,12 +5971,12 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\parent-module
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\parent-module
 │  └─ licenseFile: node_modules\parent-module\license
 ├─ parse-asn1@5.1.6
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/crypto-browserify/parse-asn1
-│  ├─ path: C:\dev\dnn-elements\node_modules\parse-asn1
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\parse-asn1
 │  └─ licenseFile: node_modules\parse-asn1\LICENSE
 ├─ parse-entities@2.0.0
 │  ├─ licenses: MIT
@@ -5967,7 +5984,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\parse-entities
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\parse-entities
 │  └─ licenseFile: node_modules\parse-entities\license
 ├─ parse-json@5.2.0
 │  ├─ licenses: MIT
@@ -5975,7 +5992,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\parse-json
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\parse-json
 │  └─ licenseFile: node_modules\parse-json\license
 ├─ parse5@6.0.1
 │  ├─ licenses: MIT
@@ -5983,12 +6000,12 @@
 │  ├─ publisher: Ivan Nikulin
 │  ├─ email: ifaaan@gmail.com
 │  ├─ url: https://github.com/inikulin
-│  ├─ path: C:\dev\dnn-elements\node_modules\parse5
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\parse5
 │  └─ licenseFile: node_modules\parse5\LICENSE
 ├─ parseurl@1.3.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/pillarjs/parseurl
-│  ├─ path: C:\dev\dnn-elements\node_modules\parseurl
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\parseurl
 │  └─ licenseFile: node_modules\parseurl\LICENSE
 ├─ pascal-case@3.1.2
 │  ├─ licenses: MIT
@@ -5996,14 +6013,14 @@
 │  ├─ publisher: Blake Embrey
 │  ├─ email: hello@blakeembrey.com
 │  ├─ url: http://blakeembrey.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\pascal-case
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pascal-case
 │  └─ licenseFile: node_modules\pascal-case\LICENSE
 ├─ pascalcase@0.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/pascalcase
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\pascalcase
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pascalcase
 │  └─ licenseFile: node_modules\pascalcase\LICENSE
 ├─ path-browserify@0.0.1
 │  ├─ licenses: MIT
@@ -6011,13 +6028,13 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\path-browserify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\path-browserify
 │  └─ licenseFile: node_modules\path-browserify\LICENSE
 ├─ path-dirname@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es128/path-dirname
 │  ├─ publisher: Elan Shanker
-│  ├─ path: C:\dev\dnn-elements\node_modules\path-dirname
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\path-dirname
 │  └─ licenseFile: node_modules\path-dirname\license
 ├─ path-exists@4.0.0
 │  ├─ licenses: MIT
@@ -6025,7 +6042,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\path-exists
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\path-exists
 │  └─ licenseFile: node_modules\path-exists\license
 ├─ path-is-absolute@1.0.1
 │  ├─ licenses: MIT
@@ -6033,27 +6050,27 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\path-is-absolute
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\path-is-absolute
 │  └─ licenseFile: node_modules\path-is-absolute\license
-├─ path-key@3.1.1
+├─ path-key@2.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/path-key
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\path-key
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\path-key
 │  └─ licenseFile: node_modules\path-key\license
 ├─ path-parse@1.0.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jbgutierrez/path-parse
 │  ├─ publisher: Javier Blanco
 │  ├─ email: http://jbgutierrez.info
-│  ├─ path: C:\dev\dnn-elements\node_modules\path-parse
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\path-parse
 │  └─ licenseFile: node_modules\path-parse\LICENSE
 ├─ path-to-regexp@0.1.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/component/path-to-regexp
-│  ├─ path: C:\dev\dnn-elements\node_modules\path-to-regexp
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\path-to-regexp
 │  └─ licenseFile: node_modules\path-to-regexp\LICENSE
 ├─ path-type@4.0.0
 │  ├─ licenses: MIT
@@ -6061,33 +6078,33 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\path-type
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\path-type
 │  └─ licenseFile: node_modules\path-type\license
 ├─ pbkdf2@3.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/pbkdf2
 │  ├─ publisher: Daniel Cousens
-│  ├─ path: C:\dev\dnn-elements\node_modules\pbkdf2
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pbkdf2
 │  └─ licenseFile: node_modules\pbkdf2\LICENSE
 ├─ pend@1.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/andrewrk/node-pend
 │  ├─ publisher: Andrew Kelley
 │  ├─ email: superjoe30@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\pend
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pend
 │  └─ licenseFile: node_modules\pend\LICENSE
-├─ picocolors@0.2.1
+├─ picocolors@1.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/alexeyraspopov/picocolors
 │  ├─ publisher: Alexey Raspopov
-│  ├─ path: C:\dev\dnn-elements\node_modules\picocolors
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\picocolors
 │  └─ licenseFile: node_modules\picocolors\LICENSE
-├─ picomatch@2.3.0
+├─ picomatch@2.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/micromatch/picomatch
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\picomatch
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\picomatch
 │  └─ licenseFile: node_modules\picomatch\LICENSE
 ├─ pidtree@0.3.1
 │  ├─ licenses: MIT
@@ -6095,7 +6112,7 @@
 │  ├─ publisher: Simone Primarosa
 │  ├─ email: simonepri@outlook.com
 │  ├─ url: https://github.com/simonepri
-│  ├─ path: C:\dev\dnn-elements\node_modules\pidtree
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pidtree
 │  └─ licenseFile: node_modules\pidtree\license
 ├─ pify@4.0.1
 │  ├─ licenses: MIT
@@ -6103,7 +6120,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\pify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pify
 │  └─ licenseFile: node_modules\pify\license
 ├─ pirates@4.0.5
 │  ├─ licenses: MIT
@@ -6111,20 +6128,20 @@
 │  ├─ publisher: Ari Porad
 │  ├─ email: ari@ariporad.com
 │  ├─ url: http://ariporad.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\pirates
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pirates
 │  └─ licenseFile: node_modules\pirates\LICENSE
-├─ pkg-dir@4.2.0
+├─ pkg-dir@5.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/pkg-dir
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\pkg-dir
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pkg-dir
 │  └─ licenseFile: node_modules\pkg-dir\license
 ├─ pnp-webpack-plugin@1.6.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/arcanis/pnp-webpack-plugin
-│  ├─ path: C:\dev\dnn-elements\node_modules\pnp-webpack-plugin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pnp-webpack-plugin
 │  └─ licenseFile: node_modules\pnp-webpack-plugin\README.md
 ├─ polished@4.1.4
 │  ├─ licenses: MIT
@@ -6132,136 +6149,136 @@
 │  ├─ publisher: Brian Hough
 │  ├─ email: hello@brianhough.net
 │  ├─ url: https://polished.js.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\polished
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\polished
 │  └─ licenseFile: node_modules\polished\LICENSE.md
 ├─ popper.js@1.16.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/FezVrasta/popper.js
 │  ├─ publisher: Federico Zivolo
 │  ├─ email: federico.zivolo@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\popper.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\popper.js
 │  └─ licenseFile: node_modules\popper.js\README.md
 ├─ posix-character-classes@0.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/posix-character-classes
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\posix-character-classes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\posix-character-classes
 │  └─ licenseFile: node_modules\posix-character-classes\LICENSE
 ├─ postcss-flexbugs-fixes@4.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/luisrudge/postcss-flexbugs-fixes
 │  ├─ publisher: Luis Rudge
 │  ├─ email: luis@luisrudge.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\postcss-flexbugs-fixes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\postcss-flexbugs-fixes
 │  └─ licenseFile: node_modules\postcss-flexbugs-fixes\LICENSE
 ├─ postcss-loader@4.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack-contrib/postcss-loader
 │  ├─ publisher: Andrey Sitnik
 │  ├─ email: andrey@sitnik.ru
-│  ├─ path: C:\dev\dnn-elements\node_modules\postcss-loader
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\postcss-loader
 │  └─ licenseFile: node_modules\postcss-loader\LICENSE
 ├─ postcss-modules-extract-imports@2.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/css-modules/postcss-modules-extract-imports
 │  ├─ publisher: Glen Maddern
-│  ├─ path: C:\dev\dnn-elements\node_modules\postcss-modules-extract-imports
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\postcss-modules-extract-imports
 │  └─ licenseFile: node_modules\postcss-modules-extract-imports\LICENSE
 ├─ postcss-modules-local-by-default@3.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/css-modules/postcss-modules-local-by-default
 │  ├─ publisher: Mark Dalgleish
-│  ├─ path: C:\dev\dnn-elements\node_modules\postcss-modules-local-by-default
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\postcss-modules-local-by-default
 │  └─ licenseFile: node_modules\postcss-modules-local-by-default\LICENSE
 ├─ postcss-modules-scope@2.2.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/css-modules/postcss-modules-scope
 │  ├─ publisher: Glen Maddern
-│  ├─ path: C:\dev\dnn-elements\node_modules\postcss-modules-scope
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\postcss-modules-scope
 │  └─ licenseFile: node_modules\postcss-modules-scope\LICENSE
 ├─ postcss-modules-values@3.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/css-modules/postcss-modules-values
 │  ├─ publisher: Glen Maddern
-│  ├─ path: C:\dev\dnn-elements\node_modules\postcss-modules-values
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\postcss-modules-values
 │  └─ licenseFile: node_modules\postcss-modules-values\LICENSE
 ├─ postcss-selector-parser@6.0.9
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/postcss/postcss-selector-parser
-│  ├─ path: C:\dev\dnn-elements\node_modules\postcss-selector-parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\postcss-selector-parser
 │  └─ licenseFile: node_modules\postcss-selector-parser\LICENSE-MIT
 ├─ postcss-value-parser@4.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/TrySound/postcss-value-parser
 │  ├─ publisher: Bogdan Chadkin
 │  ├─ email: trysound@yandex.ru
-│  ├─ path: C:\dev\dnn-elements\node_modules\postcss-value-parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\postcss-value-parser
 │  └─ licenseFile: node_modules\postcss-value-parser\LICENSE
 ├─ postcss@7.0.39
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/postcss/postcss
 │  ├─ publisher: Andrey Sitnik
 │  ├─ email: andrey@sitnik.ru
-│  ├─ path: C:\dev\dnn-elements\node_modules\postcss
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\postcss
 │  └─ licenseFile: node_modules\postcss\LICENSE
 ├─ prelude-ls@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/gkz/prelude-ls
 │  ├─ publisher: George Zahariev
 │  ├─ email: z@georgezahariev.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\prelude-ls
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\prelude-ls
 │  └─ licenseFile: node_modules\prelude-ls\LICENSE
 ├─ prettier@2.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/prettier/prettier
 │  ├─ publisher: James Long
-│  ├─ path: C:\dev\dnn-elements\node_modules\prettier
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\prettier
 │  └─ licenseFile: node_modules\prettier\LICENSE
 ├─ pretty-error@2.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/AriaMinaei/pretty-error
 │  ├─ publisher: Aria Minaei
-│  ├─ path: C:\dev\dnn-elements\node_modules\pretty-error
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pretty-error
 │  └─ licenseFile: node_modules\pretty-error\LICENSE
 ├─ pretty-format@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ publisher: James Kyle
 │  ├─ email: me@thejameskyle.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\pretty-format
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pretty-format
 │  └─ licenseFile: node_modules\pretty-format\LICENSE
 ├─ pretty-hrtime@1.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/robrich/pretty-hrtime
 │  ├─ publisher: Rob Richardson
 │  ├─ url: http://robrich.org/
-│  ├─ path: C:\dev\dnn-elements\node_modules\pretty-hrtime
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pretty-hrtime
 │  └─ licenseFile: node_modules\pretty-hrtime\LICENSE
 ├─ prismjs@1.27.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/PrismJS/prism
 │  ├─ publisher: Lea Verou
-│  ├─ path: C:\dev\dnn-elements\node_modules\prismjs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\prismjs
 │  └─ licenseFile: node_modules\prismjs\LICENSE
 ├─ process-nextick-args@2.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/calvinmetcalf/process-nextick-args
-│  ├─ path: C:\dev\dnn-elements\node_modules\process-nextick-args
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\process-nextick-args
 │  └─ licenseFile: node_modules\process-nextick-args\license.md
 ├─ process@0.11.10
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/shtylman/node-process
 │  ├─ publisher: Roman Shtylman
 │  ├─ email: shtylman@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\process
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\process
 │  └─ licenseFile: node_modules\process\LICENSE
 ├─ progress@2.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/visionmedia/node-progress
 │  ├─ publisher: TJ Holowaychuk
 │  ├─ email: tj@vision-media.ca
-│  ├─ path: C:\dev\dnn-elements\node_modules\progress
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\progress
 │  └─ licenseFile: node_modules\progress\LICENSE
 ├─ promise-inflight@1.0.1
 │  ├─ licenses: ISC
@@ -6269,21 +6286,21 @@
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
 │  ├─ url: http://re-becca.org/
-│  ├─ path: C:\dev\dnn-elements\node_modules\promise-inflight
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\promise-inflight
 │  └─ licenseFile: node_modules\promise-inflight\LICENSE
 ├─ promise.allsettled@1.0.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/Promise.allSettled
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\promise.allsettled
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\promise.allsettled
 │  └─ licenseFile: node_modules\promise.allsettled\LICENSE
 ├─ promise.prototype.finally@3.1.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/Promise.prototype.finally
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\promise.prototype.finally
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\promise.prototype.finally
 │  └─ licenseFile: node_modules\promise.prototype.finally\LICENSE
 ├─ prompts@2.4.2
 │  ├─ licenses: MIT
@@ -6291,12 +6308,12 @@
 │  ├─ publisher: Terkel Gjervig
 │  ├─ email: terkel@terkel.com
 │  ├─ url: https://terkel.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\prompts
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\prompts
 │  └─ licenseFile: node_modules\prompts\license
 ├─ prop-types@15.8.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/prop-types
-│  ├─ path: C:\dev\dnn-elements\node_modules\prop-types
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\prop-types
 │  └─ licenseFile: node_modules\prop-types\LICENSE
 ├─ property-information@5.6.0
 │  ├─ licenses: MIT
@@ -6304,14 +6321,14 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\property-information
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\property-information
 │  └─ licenseFile: node_modules\property-information\license
 ├─ proxy-addr@2.0.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/proxy-addr
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\proxy-addr
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\proxy-addr
 │  └─ licenseFile: node_modules\proxy-addr\LICENSE
 ├─ proxy-from-env@1.1.0
 │  ├─ licenses: MIT
@@ -6319,7 +6336,7 @@
 │  ├─ publisher: Rob Wu
 │  ├─ email: rob@robwu.nl
 │  ├─ url: https://robwu.nl/
-│  ├─ path: C:\dev\dnn-elements\node_modules\proxy-from-env
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\proxy-from-env
 │  └─ licenseFile: node_modules\proxy-from-env\LICENSE
 ├─ prr@1.0.1
 │  ├─ licenses: MIT
@@ -6327,7 +6344,7 @@
 │  ├─ publisher: Rod Vagg
 │  ├─ email: rod@vagg.org
 │  ├─ url: https://github.com/rvagg
-│  ├─ path: C:\dev\dnn-elements\node_modules\prr
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\prr
 │  └─ licenseFile: node_modules\prr\LICENSE.md
 ├─ psl@1.8.0
 │  ├─ licenses: MIT
@@ -6335,58 +6352,58 @@
 │  ├─ publisher: Lupo Montero
 │  ├─ email: lupomontero@gmail.com
 │  ├─ url: https://lupomontero.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\psl
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\psl
 │  └─ licenseFile: node_modules\psl\LICENSE
 ├─ public-encrypt@4.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/publicEncrypt
 │  ├─ publisher: Calvin Metcalf
-│  ├─ path: C:\dev\dnn-elements\node_modules\public-encrypt
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\public-encrypt
 │  └─ licenseFile: node_modules\public-encrypt\LICENSE
 ├─ pump@3.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/pump
 │  ├─ publisher: Mathias Buus Madsen
 │  ├─ email: mathiasbuus@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\pump
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pump
 │  └─ licenseFile: node_modules\pump\LICENSE
 ├─ pumpify@1.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/pumpify
 │  ├─ publisher: Mathias Buus
-│  ├─ path: C:\dev\dnn-elements\node_modules\pumpify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pumpify
 │  └─ licenseFile: node_modules\pumpify\LICENSE
 ├─ punycode@2.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/bestiejs/punycode.js
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\punycode
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\punycode
 │  └─ licenseFile: node_modules\punycode\LICENSE-MIT.txt
-├─ puppeteer@13.4.1
+├─ puppeteer@13.5.1
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/puppeteer/puppeteer
 │  ├─ publisher: The Chromium Authors
-│  ├─ path: C:\dev\dnn-elements\node_modules\puppeteer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\puppeteer
 │  └─ licenseFile: node_modules\puppeteer\LICENSE
 ├─ qs@6.10.3
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/ljharb/qs
-│  ├─ path: C:\dev\dnn-elements\node_modules\qs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\qs
 │  └─ licenseFile: node_modules\qs\LICENSE.md
 ├─ querystring-es3@0.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mike-spainhower/querystring
 │  ├─ publisher: Irakli Gozalishvili
 │  ├─ email: rfobic@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\querystring-es3
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\querystring-es3
 │  └─ licenseFile: node_modules\querystring-es3\License.md
 ├─ querystring@0.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Gozala/querystring
 │  ├─ publisher: Irakli Gozalishvili
 │  ├─ email: rfobic@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\querystring
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\querystring
 │  └─ licenseFile: node_modules\querystring\License.md
 ├─ queue-microtask@1.2.3
 │  ├─ licenses: MIT
@@ -6394,7 +6411,7 @@
 │  ├─ publisher: Feross Aboukhadijeh
 │  ├─ email: feross@feross.org
 │  ├─ url: https://feross.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\queue-microtask
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\queue-microtask
 │  └─ licenseFile: node_modules\queue-microtask\LICENSE
 ├─ ramda@0.21.0
 │  ├─ licenses: MIT
@@ -6402,17 +6419,17 @@
 │  ├─ publisher: Scott Sauyet
 │  ├─ email: scott@sauyet.com
 │  ├─ url: scott.sauyet.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\ramda
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ramda
 │  └─ licenseFile: node_modules\ramda\LICENSE.txt
 ├─ randombytes@2.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/randombytes
-│  ├─ path: C:\dev\dnn-elements\node_modules\randombytes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\randombytes
 │  └─ licenseFile: node_modules\randombytes\LICENSE
 ├─ randomfill@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/randomfill
-│  ├─ path: C:\dev\dnn-elements\node_modules\randomfill
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\randomfill
 │  └─ licenseFile: node_modules\randomfill\LICENSE
 ├─ range-parser@1.2.1
 │  ├─ licenses: MIT
@@ -6420,7 +6437,7 @@
 │  ├─ publisher: TJ Holowaychuk
 │  ├─ email: tj@vision-media.ca
 │  ├─ url: http://tjholowaychuk.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\range-parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\range-parser
 │  └─ licenseFile: node_modules\range-parser\LICENSE
 ├─ raw-body@2.4.3
 │  ├─ licenses: MIT
@@ -6428,13 +6445,13 @@
 │  ├─ publisher: Jonathan Ong
 │  ├─ email: me@jongleberry.com
 │  ├─ url: http://jongleberry.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\raw-body
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\raw-body
 │  └─ licenseFile: node_modules\raw-body\LICENSE
 ├─ raw-loader@4.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack-contrib/raw-loader
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\raw-loader
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\raw-loader
 │  └─ licenseFile: node_modules\raw-loader\LICENSE
 ├─ react-clientside-effect@1.2.5
 │  ├─ licenses: MIT
@@ -6442,52 +6459,52 @@
 │  ├─ publisher: Dan Abramov
 │  ├─ email: dan.abramov@me.com
 │  ├─ url: http://github.com/gaearon
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-clientside-effect
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-clientside-effect
 │  └─ licenseFile: node_modules\react-clientside-effect\LICENSE
 ├─ react-colorful@5.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/omgovich/react-colorful
 │  ├─ publisher: Vlad Shilov
 │  ├─ email: omgovich@ya.ru
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-colorful
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-colorful
 │  └─ licenseFile: node_modules\react-colorful\LICENSE
-├─ react-dom@16.14.0
+├─ react-dom@17.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/react
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-dom
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-dom
 │  └─ licenseFile: node_modules\react-dom\LICENSE
 ├─ react-draggable@4.4.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/react-grid-layout/react-draggable
 │  ├─ publisher: Matt Zabriskie
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-draggable
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-draggable
 │  └─ licenseFile: node_modules\react-draggable\LICENSE
 ├─ react-element-to-jsx-string@14.3.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/algolia/react-element-to-jsx-string
 │  ├─ publisher: Algolia, Inc.
 │  ├─ url: https://github.com/algolia
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-element-to-jsx-string
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-element-to-jsx-string
 │  └─ licenseFile: node_modules\react-element-to-jsx-string\LICENSE
 ├─ react-fast-compare@3.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/FormidableLabs/react-fast-compare
 │  ├─ publisher: Chris Bolin
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-fast-compare
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-fast-compare
 │  └─ licenseFile: node_modules\react-fast-compare\LICENSE
 ├─ react-focus-lock@2.8.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/theKashey/react-focus-lock
 │  ├─ publisher: theKashey
 │  ├─ email: thekashey@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-focus-lock
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-focus-lock
 │  └─ licenseFile: node_modules\react-focus-lock\LICENSE
 ├─ react-helmet-async@1.2.3
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/staylor/react-helmet-async
 │  ├─ publisher: Scott Taylor
 │  ├─ email: scott.c.taylor@mac.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-helmet-async
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-helmet-async
 │  └─ licenseFile: node_modules\react-helmet-async\LICENSE
 ├─ react-inspector@5.1.1
 │  ├─ licenses: MIT
@@ -6495,24 +6512,24 @@
 │  ├─ publisher: Xiaoyi Chen
 │  ├─ email: cxychina@gmail.com
 │  ├─ url: http://github.com/xyc
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-inspector
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-inspector
 │  └─ licenseFile: node_modules\react-inspector\LICENSE
-├─ react-is@16.13.1
+├─ react-is@17.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/react
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-is
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-is
 │  └─ licenseFile: node_modules\react-is\LICENSE
 ├─ react-lifecycles-compat@3.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/reactjs/react-lifecycles-compat
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-lifecycles-compat
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-lifecycles-compat
 │  └─ licenseFile: node_modules\react-lifecycles-compat\LICENSE.md
 ├─ react-popper-tooltip@3.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mohsinulhaq/react-popper-tooltip
 │  ├─ publisher: Mohsin Ul Haq
 │  ├─ email: mohsinulhaq01@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-popper-tooltip
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-popper-tooltip
 │  └─ licenseFile: node_modules\react-popper-tooltip\LICENSE
 ├─ react-popper@2.2.5
 │  ├─ licenses: MIT
@@ -6520,34 +6537,34 @@
 │  ├─ publisher: Travis Arnold
 │  ├─ email: travis@souporserious.com
 │  ├─ url: http://souporserious.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-popper
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-popper
 │  └─ licenseFile: node_modules\react-popper\LICENSE
 ├─ react-router-dom@6.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/remix-run/react-router
 │  ├─ publisher: Remix Software
 │  ├─ email: hello@remix.run
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-router-dom
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-router-dom
 │  └─ licenseFile: node_modules\react-router-dom\LICENSE.md
 ├─ react-router@6.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/remix-run/react-router
 │  ├─ publisher: Remix Software
 │  ├─ email: hello@remix.run
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-router
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-router
 │  └─ licenseFile: node_modules\react-router\LICENSE.md
 ├─ react-sizeme@3.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ctrlplusb/react-sizeme
 │  ├─ publisher: Sean Matheson
 │  ├─ email: sean@ctrlplusb.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-sizeme
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-sizeme
 │  └─ licenseFile: node_modules\react-sizeme\LICENSE
 ├─ react-syntax-highlighter@13.5.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/react-syntax-highlighter/react-syntax-highlighter
 │  ├─ publisher: Conor Hastings
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-syntax-highlighter
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-syntax-highlighter
 │  └─ licenseFile: node_modules\react-syntax-highlighter\LICENSE
 ├─ react-textarea-autosize@8.3.3
 │  ├─ licenses: MIT
@@ -6555,12 +6572,12 @@
 │  ├─ publisher: Andrey Popp
 │  ├─ email: 8mayday@gmail.com
 │  ├─ url: httsps://andreypopp.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\react-textarea-autosize
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react-textarea-autosize
 │  └─ licenseFile: node_modules\react-textarea-autosize\LICENSE
-├─ react@16.14.0
+├─ react@17.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/react
-│  ├─ path: C:\dev\dnn-elements\node_modules\react
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\react
 │  └─ licenseFile: node_modules\react\LICENSE
 ├─ read-installed@4.0.3
 │  ├─ licenses: ISC
@@ -6568,7 +6585,7 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\read-installed
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\read-installed
 │  └─ licenseFile: node_modules\read-installed\LICENSE
 ├─ read-package-json@2.1.2
 │  ├─ licenses: ISC
@@ -6576,7 +6593,7 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\read-package-json
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\read-package-json
 │  └─ licenseFile: node_modules\read-package-json\LICENSE
 ├─ read-pkg-up@7.0.1
 │  ├─ licenses: MIT
@@ -6584,7 +6601,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\read-pkg-up
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\read-pkg-up
 │  └─ licenseFile: node_modules\read-pkg-up\license
 ├─ read-pkg@5.2.0
 │  ├─ licenses: MIT
@@ -6592,12 +6609,12 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\read-pkg
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\read-pkg
 │  └─ licenseFile: node_modules\read-pkg\license
 ├─ readable-stream@3.6.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/nodejs/readable-stream
-│  ├─ path: C:\dev\dnn-elements\node_modules\readable-stream
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\readable-stream
 │  └─ licenseFile: node_modules\readable-stream\LICENSE
 ├─ readdir-scoped-modules@1.1.0
 │  ├─ licenses: ISC
@@ -6605,7 +6622,7 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\readdir-scoped-modules
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\readdir-scoped-modules
 │  └─ licenseFile: node_modules\readdir-scoped-modules\LICENSE
 ├─ readdirp@3.6.0
 │  ├─ licenses: MIT
@@ -6613,7 +6630,7 @@
 │  ├─ publisher: Thorsten Lorenz
 │  ├─ email: thlorenz@gmx.de
 │  ├─ url: thlorenz.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\readdirp
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\readdirp
 │  └─ licenseFile: node_modules\readdirp\LICENSE
 ├─ refractor@3.6.0
 │  ├─ licenses: MIT
@@ -6621,77 +6638,77 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\refractor
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\refractor
 │  └─ licenseFile: node_modules\refractor\license
 ├─ regenerate-unicode-properties@10.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/regenerate-unicode-properties
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\regenerate-unicode-properties
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regenerate-unicode-properties
 │  └─ licenseFile: node_modules\regenerate-unicode-properties\LICENSE-MIT.txt
 ├─ regenerate@1.4.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/regenerate
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\regenerate
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regenerate
 │  └─ licenseFile: node_modules\regenerate\LICENSE-MIT.txt
 ├─ regenerator-runtime@0.13.9
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/regenerator/tree/master/packages/runtime
 │  ├─ publisher: Ben Newman
 │  ├─ email: bn@cs.stanford.edu
-│  ├─ path: C:\dev\dnn-elements\node_modules\regenerator-runtime
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regenerator-runtime
 │  └─ licenseFile: node_modules\regenerator-runtime\LICENSE
 ├─ regenerator-transform@0.14.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/regenerator/tree/master/packages/regenerator-transform
 │  ├─ publisher: Ben Newman
 │  ├─ email: bn@cs.stanford.edu
-│  ├─ path: C:\dev\dnn-elements\node_modules\regenerator-transform
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regenerator-transform
 │  └─ licenseFile: node_modules\regenerator-transform\LICENSE
 ├─ regex-not@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/regex-not
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\regex-not
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regex-not
 │  └─ licenseFile: node_modules\regex-not\LICENSE
-├─ regexp.prototype.flags@1.3.1
+├─ regexp.prototype.flags@1.4.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/RegExp.prototype.flags
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\regexp.prototype.flags
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regexp.prototype.flags
 │  └─ licenseFile: node_modules\regexp.prototype.flags\LICENSE
 ├─ regexpp@3.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mysticatea/regexpp
 │  ├─ publisher: Toru Nagashima
 │  ├─ url: https://github.com/mysticatea
-│  ├─ path: C:\dev\dnn-elements\node_modules\regexpp
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regexpp
 │  └─ licenseFile: node_modules\regexpp\LICENSE
 ├─ regexpu-core@5.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/regexpu-core
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\regexpu-core
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regexpu-core
 │  └─ licenseFile: node_modules\regexpu-core\LICENSE-MIT.txt
 ├─ regjsgen@0.6.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/bnjmnt4n/regjsgen
 │  ├─ publisher: Benjamin Tan
 │  ├─ url: https://ofcr.se/
-│  ├─ path: C:\dev\dnn-elements\node_modules\regjsgen
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regjsgen
 │  └─ licenseFile: node_modules\regjsgen\LICENSE-MIT.txt
 ├─ regjsparser@0.8.4
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/jviereck/regjsparser
 │  ├─ publisher: 'Julian Viereck'
 │  ├─ email: julian.viereck@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\regjsparser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regjsparser
 │  └─ licenseFile: node_modules\regjsparser\LICENSE.BSD
 ├─ relateurl@0.2.7
 │  ├─ licenses: MIT
@@ -6699,14 +6716,14 @@
 │  ├─ publisher: Steven Vachon
 │  ├─ email: contact@svachon.com
 │  ├─ url: http://www.svachon.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\relateurl
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\relateurl
 │  └─ licenseFile: node_modules\relateurl\license
 ├─ remark-external-links@8.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/remarkjs/remark-external-links
 │  ├─ publisher: Cédric Delpoux
 │  ├─ email: xuopled@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\remark-external-links
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\remark-external-links
 │  └─ licenseFile: node_modules\remark-external-links\license
 ├─ remark-footnotes@2.0.0
 │  ├─ licenses: MIT
@@ -6714,7 +6731,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\remark-footnotes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\remark-footnotes
 │  └─ licenseFile: node_modules\remark-footnotes\license
 ├─ remark-mdx@1.6.22
 │  ├─ licenses: MIT
@@ -6722,7 +6739,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\remark-mdx
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\remark-mdx
 │  └─ licenseFile: node_modules\remark-mdx\license
 ├─ remark-parse@8.0.3
 │  ├─ licenses: MIT
@@ -6730,7 +6747,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\remark-parse
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\remark-parse
 │  └─ licenseFile: node_modules\remark-parse\readme.md
 ├─ remark-slug@6.1.0
 │  ├─ licenses: MIT
@@ -6738,40 +6755,40 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\remark-slug
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\remark-slug
 │  └─ licenseFile: node_modules\remark-slug\license
 ├─ remark-squeeze-paragraphs@4.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/remarkjs/remark-squeeze-paragraphs
 │  ├─ publisher: Eugene Sharygin
 │  ├─ email: eush77@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\remark-squeeze-paragraphs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\remark-squeeze-paragraphs
 │  └─ licenseFile: node_modules\remark-squeeze-paragraphs\license
 ├─ remove-trailing-separator@1.1.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/darsain/remove-trailing-separator
 │  ├─ publisher: darsain
-│  ├─ path: C:\dev\dnn-elements\node_modules\remove-trailing-separator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\remove-trailing-separator
 │  └─ licenseFile: node_modules\remove-trailing-separator\license
 ├─ renderkid@2.0.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/AriaMinaei/RenderKid
 │  ├─ publisher: Aria Minaei
-│  ├─ path: C:\dev\dnn-elements\node_modules\renderkid
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\renderkid
 │  └─ licenseFile: node_modules\renderkid\LICENSE
 ├─ repeat-element@1.1.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/repeat-element
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\repeat-element
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\repeat-element
 │  └─ licenseFile: node_modules\repeat-element\LICENSE
 ├─ repeat-string@1.6.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/repeat-string
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: http://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\repeat-string
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\repeat-string
 │  └─ licenseFile: node_modules\repeat-string\LICENSE
 ├─ require-directory@2.1.1
 │  ├─ licenses: MIT
@@ -6779,7 +6796,7 @@
 │  ├─ publisher: Troy Goode
 │  ├─ email: troygoode@gmail.com
 │  ├─ url: http://github.com/troygoode/
-│  ├─ path: C:\dev\dnn-elements\node_modules\require-directory
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\require-directory
 │  └─ licenseFile: node_modules\require-directory\LICENSE
 ├─ require-from-string@2.0.2
 │  ├─ licenses: MIT
@@ -6787,14 +6804,14 @@
 │  ├─ publisher: Vsevolod Strukchinsky
 │  ├─ email: floatdrop@gmail.com
 │  ├─ url: github.com/floatdrop
-│  ├─ path: C:\dev\dnn-elements\node_modules\require-from-string
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\require-from-string
 │  └─ licenseFile: node_modules\require-from-string\license
 ├─ resize-observer-polyfill@1.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/que-etc/resize-observer-polyfill
 │  ├─ publisher: Denis Rul
 │  ├─ email: que.etc@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\resize-observer-polyfill
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\resize-observer-polyfill
 │  └─ licenseFile: node_modules\resize-observer-polyfill\LICENSE
 ├─ resolve-cwd@3.0.0
 │  ├─ licenses: MIT
@@ -6802,21 +6819,21 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\resolve-cwd
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\resolve-cwd
 │  └─ licenseFile: node_modules\resolve-cwd\license
-├─ resolve-from@4.0.0
+├─ resolve-from@5.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/resolve-from
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\resolve-from
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\resolve-from
 │  └─ licenseFile: node_modules\resolve-from\license
 ├─ resolve-url@0.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lydell/resolve-url
 │  ├─ publisher: Simon Lydell
-│  ├─ path: C:\dev\dnn-elements\node_modules\resolve-url
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\resolve-url
 │  └─ licenseFile: node_modules\resolve-url\LICENSE
 ├─ resolve.exports@1.1.0
 │  ├─ licenses: MIT
@@ -6824,48 +6841,48 @@
 │  ├─ publisher: Luke Edwards
 │  ├─ email: luke.edwards05@gmail.com
 │  ├─ url: https://lukeed.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\resolve.exports
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\resolve.exports
 │  └─ licenseFile: node_modules\resolve.exports\license
-├─ resolve@1.20.0
+├─ resolve@1.22.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/browserify/resolve
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\resolve
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\resolve
 │  └─ licenseFile: node_modules\resolve\LICENSE
 ├─ ret@0.1.15
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/fent/ret.js
 │  ├─ publisher: Roly Fentanes
 │  ├─ url: https://github.com/fent
-│  ├─ path: C:\dev\dnn-elements\node_modules\ret
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ret
 │  └─ licenseFile: node_modules\ret\LICENSE
 ├─ reusify@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mcollina/reusify
 │  ├─ publisher: Matteo Collina
 │  ├─ email: hello@matteocollina.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\reusify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\reusify
 │  └─ licenseFile: node_modules\reusify\LICENSE
-├─ rimraf@3.0.2
+├─ rimraf@2.7.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/rimraf
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\rimraf
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\rimraf
 │  └─ licenseFile: node_modules\rimraf\LICENSE
 ├─ ripemd160@2.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/crypto-browserify/ripemd160
-│  ├─ path: C:\dev\dnn-elements\node_modules\ripemd160
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ripemd160
 │  └─ licenseFile: node_modules\ripemd160\LICENSE
 ├─ rsvp@4.8.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/tildeio/rsvp.js
 │  ├─ publisher: Tilde, Inc. & Stefan Penner
-│  ├─ path: C:\dev\dnn-elements\node_modules\rsvp
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\rsvp
 │  └─ licenseFile: node_modules\rsvp\LICENSE
 ├─ run-parallel@1.2.0
 │  ├─ licenses: MIT
@@ -6873,7 +6890,7 @@
 │  ├─ publisher: Feross Aboukhadijeh
 │  ├─ email: feross@feross.org
 │  ├─ url: https://feross.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\run-parallel
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\run-parallel
 │  └─ licenseFile: node_modules\run-parallel\LICENSE
 ├─ run-queue@1.0.3
 │  ├─ licenses: ISC
@@ -6881,7 +6898,7 @@
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
 │  ├─ url: http://re-becca.org/
-│  ├─ path: C:\dev\dnn-elements\node_modules\run-queue
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\run-queue
 │  └─ licenseFile: node_modules\run-queue\README.md
 ├─ safe-buffer@5.1.2
 │  ├─ licenses: MIT
@@ -6889,7 +6906,7 @@
 │  ├─ publisher: Feross Aboukhadijeh
 │  ├─ email: feross@feross.org
 │  ├─ url: http://feross.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\safe-buffer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\safe-buffer
 │  └─ licenseFile: node_modules\safe-buffer\LICENSE
 ├─ safe-regex@1.1.0
 │  ├─ licenses: MIT
@@ -6897,7 +6914,7 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\safe-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\safe-regex
 │  └─ licenseFile: node_modules\safe-regex\LICENSE
 ├─ safer-buffer@2.1.2
 │  ├─ licenses: MIT
@@ -6905,96 +6922,96 @@
 │  ├─ publisher: Nikita Skovoroda
 │  ├─ email: chalkerx@gmail.com
 │  ├─ url: https://github.com/ChALkeR
-│  ├─ path: C:\dev\dnn-elements\node_modules\safer-buffer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\safer-buffer
 │  └─ licenseFile: node_modules\safer-buffer\LICENSE
 ├─ sane@4.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/amasad/sane
 │  ├─ publisher: amasad
-│  ├─ path: C:\dev\dnn-elements\node_modules\sane
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\sane
 │  └─ licenseFile: node_modules\sane\README.md
 ├─ saxes@5.0.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/lddubeau/saxes
 │  ├─ publisher: Louis-Dominique Dubeau
 │  ├─ email: ldd@lddubeau.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\saxes
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\saxes
 │  └─ licenseFile: node_modules\saxes\README.md
-├─ scheduler@0.19.1
+├─ scheduler@0.20.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/react
-│  ├─ path: C:\dev\dnn-elements\node_modules\scheduler
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\scheduler
 │  └─ licenseFile: node_modules\scheduler\LICENSE
 ├─ schema-utils@2.7.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/schema-utils
 │  ├─ publisher: webpack Contrib
 │  ├─ url: https://github.com/webpack-contrib
-│  ├─ path: C:\dev\dnn-elements\node_modules\schema-utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\schema-utils
 │  └─ licenseFile: node_modules\schema-utils\LICENSE
 ├─ select@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zenorocha/select
-│  ├─ path: C:\dev\dnn-elements\node_modules\select
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\select
 │  └─ licenseFile: node_modules\select\readme.md
 ├─ semver@6.3.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/npm/node-semver
-│  ├─ path: C:\dev\dnn-elements\node_modules\semver
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\semver
 │  └─ licenseFile: node_modules\semver\LICENSE
 ├─ send@0.17.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/pillarjs/send
 │  ├─ publisher: TJ Holowaychuk
 │  ├─ email: tj@vision-media.ca
-│  ├─ path: C:\dev\dnn-elements\node_modules\send
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\send
 │  └─ licenseFile: node_modules\send\LICENSE
-├─ serialize-javascript@5.0.1
+├─ serialize-javascript@4.0.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/yahoo/serialize-javascript
 │  ├─ publisher: Eric Ferraiuolo
 │  ├─ email: edf@ericf.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\serialize-javascript
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\serialize-javascript
 │  └─ licenseFile: node_modules\serialize-javascript\LICENSE
 ├─ serve-favicon@2.5.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/expressjs/serve-favicon
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\serve-favicon
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\serve-favicon
 │  └─ licenseFile: node_modules\serve-favicon\LICENSE
 ├─ serve-static@1.14.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/expressjs/serve-static
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\serve-static
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\serve-static
 │  └─ licenseFile: node_modules\serve-static\LICENSE
 ├─ set-blocking@2.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/yargs/set-blocking
 │  ├─ publisher: Ben Coe
 │  ├─ email: ben@npmjs.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\set-blocking
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\set-blocking
 │  └─ licenseFile: node_modules\set-blocking\LICENSE.txt
 ├─ set-value@2.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/set-value
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\set-value
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\set-value
 │  └─ licenseFile: node_modules\set-value\LICENSE
 ├─ setimmediate@1.0.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/YuzuJS/setImmediate
 │  ├─ publisher: YuzuJS
-│  ├─ path: C:\dev\dnn-elements\node_modules\setimmediate
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\setimmediate
 │  └─ licenseFile: node_modules\setimmediate\LICENSE.txt
 ├─ setprototypeof@1.2.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/wesleytodd/setprototypeof
 │  ├─ publisher: Wes Todd
-│  ├─ path: C:\dev\dnn-elements\node_modules\setprototypeof
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\setprototypeof
 │  └─ licenseFile: node_modules\setprototypeof\LICENSE
 ├─ sha.js@2.4.11
 │  ├─ licenses: (MIT AND BSD-3-Clause)
@@ -7002,21 +7019,21 @@
 │  ├─ publisher: Dominic Tarr
 │  ├─ email: dominic.tarr@gmail.com
 │  ├─ url: dominictarr.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\sha.js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\sha.js
 │  └─ licenseFile: node_modules\sha.js\LICENSE
 ├─ shallow-clone@3.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/shallow-clone
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\shallow-clone
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\shallow-clone
 │  └─ licenseFile: node_modules\shallow-clone\LICENSE
 ├─ shallow-equal@1.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/moroshko/shallow-equal
 │  ├─ publisher: Misha Moroshko
 │  ├─ email: michael.moroshko@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\shallow-equal
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\shallow-equal
 │  └─ licenseFile: node_modules\shallow-equal\LICENSE
 ├─ shallowequal@1.1.0
 │  ├─ licenses: MIT
@@ -7024,23 +7041,23 @@
 │  ├─ publisher: Alberto Leal
 │  ├─ email: mailforalberto@gmail.com
 │  ├─ url: github.com/dashed
-│  ├─ path: C:\dev\dnn-elements\node_modules\shallowequal
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\shallowequal
 │  └─ licenseFile: node_modules\shallowequal\LICENSE
-├─ shebang-command@2.0.0
+├─ shebang-command@1.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/kevva/shebang-command
-│  ├─ publisher: Kevin Mårtensson
+│  ├─ publisher: Kevin Martensson
 │  ├─ email: kevinmartensson@gmail.com
 │  ├─ url: github.com/kevva
-│  ├─ path: C:\dev\dnn-elements\node_modules\shebang-command
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\shebang-command
 │  └─ licenseFile: node_modules\shebang-command\license
-├─ shebang-regex@3.0.0
+├─ shebang-regex@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/shebang-regex
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\shebang-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\shebang-regex
 │  └─ licenseFile: node_modules\shebang-regex\license
 ├─ shell-quote@1.7.3
 │  ├─ licenses: MIT
@@ -7048,33 +7065,33 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\shell-quote
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\shell-quote
 │  └─ licenseFile: node_modules\shell-quote\LICENSE
 ├─ side-channel@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/side-channel
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\side-channel
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\side-channel
 │  └─ licenseFile: node_modules\side-channel\LICENSE
-├─ signal-exit@3.0.5
+├─ signal-exit@3.0.7
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/tapjs/signal-exit
 │  ├─ publisher: Ben Coe
 │  ├─ email: ben@npmjs.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\signal-exit
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\signal-exit
 │  └─ licenseFile: node_modules\signal-exit\LICENSE.txt
 ├─ simplebar-react@1.2.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/grsmto/simplebar
 │  ├─ publisher: Adrien Denat
-│  ├─ path: C:\dev\dnn-elements\node_modules\simplebar-react
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\simplebar-react
 │  └─ licenseFile: node_modules\simplebar-react\LICENSE
 ├─ simplebar@4.2.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/grsmto/simplebar
 │  ├─ publisher: Adrien Denat from a fork by Jonathan Nicol
-│  ├─ path: C:\dev\dnn-elements\node_modules\simplebar
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\simplebar
 │  └─ licenseFile: node_modules\simplebar\LICENSE
 ├─ sisteransi@1.0.5
 │  ├─ licenses: MIT
@@ -7082,7 +7099,7 @@
 │  ├─ publisher: Terkel Gjervig
 │  ├─ email: terkel@terkel.com
 │  ├─ url: https://terkel.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\sisteransi
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\sisteransi
 │  └─ licenseFile: node_modules\sisteransi\license
 ├─ slash@3.0.0
 │  ├─ licenses: MIT
@@ -7090,12 +7107,12 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\slash
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\slash
 │  └─ licenseFile: node_modules\slash\license
 ├─ slice-ansi@4.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/chalk/slice-ansi
-│  ├─ path: C:\dev\dnn-elements\node_modules\slice-ansi
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\slice-ansi
 │  └─ licenseFile: node_modules\slice-ansi\license
 ├─ slide@1.1.6
 │  ├─ licenses: ISC
@@ -7103,58 +7120,58 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\slide
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\slide
 │  └─ licenseFile: node_modules\slide\LICENSE
 ├─ snapdragon-node@2.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/snapdragon-node
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\snapdragon-node
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\snapdragon-node
 │  └─ licenseFile: node_modules\snapdragon-node\LICENSE
 ├─ snapdragon-util@3.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/snapdragon-util
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\snapdragon-util
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\snapdragon-util
 │  └─ licenseFile: node_modules\snapdragon-util\LICENSE
 ├─ snapdragon@0.8.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/snapdragon
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\snapdragon
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\snapdragon
 │  └─ licenseFile: node_modules\snapdragon\LICENSE
 ├─ source-list-map@2.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/source-list-map
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\source-list-map
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\source-list-map
 │  └─ licenseFile: node_modules\source-list-map\LICENSE
 ├─ source-map-resolve@0.5.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lydell/source-map-resolve
 │  ├─ publisher: Simon Lydell
-│  ├─ path: C:\dev\dnn-elements\node_modules\source-map-resolve
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\source-map-resolve
 │  └─ licenseFile: node_modules\source-map-resolve\LICENSE
-├─ source-map-support@0.5.20
+├─ source-map-support@0.5.21
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/evanw/node-source-map-support
-│  ├─ path: C:\dev\dnn-elements\node_modules\source-map-support
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\source-map-support
 │  └─ licenseFile: node_modules\source-map-support\LICENSE.md
 ├─ source-map-url@0.4.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lydell/source-map-url
 │  ├─ publisher: Simon Lydell
-│  ├─ path: C:\dev\dnn-elements\node_modules\source-map-url
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\source-map-url
 │  └─ licenseFile: node_modules\source-map-url\LICENSE
-├─ source-map@0.6.1
+├─ source-map@0.5.7
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/mozilla/source-map
 │  ├─ publisher: Nick Fitzgerald
 │  ├─ email: nfitzgerald@mozilla.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\source-map
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\source-map
 │  └─ licenseFile: node_modules\source-map\LICENSE
 ├─ space-separated-tokens@1.1.5
 │  ├─ licenses: MIT
@@ -7162,7 +7179,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\space-separated-tokens
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\space-separated-tokens
 │  └─ licenseFile: node_modules\space-separated-tokens\license
 ├─ spdx-compare@1.0.0
 │  ├─ licenses: MIT
@@ -7170,7 +7187,7 @@
 │  ├─ publisher: Kyle E. Mitchell
 │  ├─ email: kyle@kemitchell.com
 │  ├─ url: https://kemitchell.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\spdx-compare
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\spdx-compare
 │  └─ licenseFile: node_modules\spdx-compare\LICENSE.md
 ├─ spdx-correct@3.1.1
 │  ├─ licenses: Apache-2.0
@@ -7178,13 +7195,13 @@
 │  ├─ publisher: Kyle E. Mitchell
 │  ├─ email: kyle@kemitchell.com
 │  ├─ url: https://kemitchell.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\spdx-correct
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\spdx-correct
 │  └─ licenseFile: node_modules\spdx-correct\LICENSE
 ├─ spdx-exceptions@2.3.0
 │  ├─ licenses: CC-BY-3.0
 │  ├─ repository: https://github.com/kemitchell/spdx-exceptions.json
 │  ├─ publisher: The Linux Foundation
-│  ├─ path: C:\dev\dnn-elements\node_modules\spdx-exceptions
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\spdx-exceptions
 │  └─ licenseFile: node_modules\spdx-exceptions\README.md
 ├─ spdx-expression-parse@3.0.1
 │  ├─ licenses: MIT
@@ -7192,20 +7209,20 @@
 │  ├─ publisher: Kyle E. Mitchell
 │  ├─ email: kyle@kemitchell.com
 │  ├─ url: https://kemitchell.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\spdx-expression-parse
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\spdx-expression-parse
 │  └─ licenseFile: node_modules\spdx-expression-parse\LICENSE
-├─ spdx-license-ids@3.0.10
+├─ spdx-license-ids@3.0.11
 │  ├─ licenses: CC0-1.0
 │  ├─ repository: https://github.com/jslicense/spdx-license-ids
 │  ├─ publisher: Shinnosuke Watanabe
 │  ├─ url: https://github.com/shinnn
-│  ├─ path: C:\dev\dnn-elements\node_modules\spdx-license-ids
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\spdx-license-ids
 │  └─ licenseFile: node_modules\spdx-license-ids\README.md
 ├─ spdx-ranges@2.1.1
 │  ├─ licenses: (MIT AND CC-BY-3.0)
 │  ├─ repository: https://github.com/kemitchell/spdx-ranges.js
 │  ├─ publisher: The Linux Foundation
-│  ├─ path: C:\dev\dnn-elements\node_modules\spdx-ranges
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\spdx-ranges
 │  └─ licenseFile: node_modules\spdx-ranges\LICENSE.md
 ├─ spdx-satisfies@4.0.1
 │  ├─ licenses: MIT
@@ -7213,14 +7230,14 @@
 │  ├─ publisher: Kyle E. Mitchell
 │  ├─ email: kyle@kemitchell.com
 │  ├─ url: https://kemitchell.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\spdx-satisfies
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\spdx-satisfies
 │  └─ licenseFile: node_modules\spdx-satisfies\LICENSE
 ├─ split-string@3.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/split-string
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\split-string
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\split-string
 │  └─ licenseFile: node_modules\split-string\LICENSE
 ├─ sprintf-js@1.0.3
 │  ├─ licenses: BSD-3-Clause
@@ -7228,21 +7245,21 @@
 │  ├─ publisher: Alexandru Marasteanu
 │  ├─ email: hello@alexei.ro
 │  ├─ url: http://alexei.ro/
-│  ├─ path: C:\dev\dnn-elements\node_modules\sprintf-js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\sprintf-js
 │  └─ licenseFile: node_modules\sprintf-js\LICENSE
-├─ ssri@8.0.1
+├─ ssri@6.0.2
 │  ├─ licenses: ISC
-│  ├─ repository: https://github.com/npm/ssri
+│  ├─ repository: https://github.com/zkat/ssri
 │  ├─ publisher: Kat Marchán
 │  ├─ email: kzm@sykosomatic.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\ssri
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ssri
 │  └─ licenseFile: node_modules\ssri\LICENSE.md
 ├─ stable@0.1.8
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Two-Screen/stable
 │  ├─ publisher: Angry Bytes
 │  ├─ email: info@angrybytes.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\stable
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\stable
 │  └─ licenseFile: node_modules\stable\README.md
 ├─ stack-utils@2.0.5
 │  ├─ licenses: MIT
@@ -7250,7 +7267,7 @@
 │  ├─ publisher: James Talmage
 │  ├─ email: james@talmage.io
 │  ├─ url: github.com/jamestalmage
-│  ├─ path: C:\dev\dnn-elements\node_modules\stack-utils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\stack-utils
 │  └─ licenseFile: node_modules\stack-utils\license
 ├─ state-toggle@1.0.3
 │  ├─ licenses: MIT
@@ -7258,27 +7275,27 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\state-toggle
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\state-toggle
 │  └─ licenseFile: node_modules\state-toggle\license
 ├─ static-extend@0.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/static-extend
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\static-extend
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\static-extend
 │  └─ licenseFile: node_modules\static-extend\LICENSE
 ├─ statuses@1.5.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/statuses
-│  ├─ path: C:\dev\dnn-elements\node_modules\statuses
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\statuses
 │  └─ licenseFile: node_modules\statuses\LICENSE
-├─ store2@2.13.1
+├─ store2@2.13.2
 │  ├─ licenses: (MIT OR GPL-3.0)
 │  ├─ repository: https://github.com/nbubna/store
 │  ├─ publisher: Nathan Bubna
 │  ├─ email: nathan@esha.com
 │  ├─ url: http://www.esha.com/
-│  ├─ path: C:\dev\dnn-elements\node_modules\store2
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\store2
 │  └─ licenseFile: node_modules\store2\README.md
 ├─ stream-browserify@2.0.2
 │  ├─ licenses: MIT
@@ -7286,27 +7303,27 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\stream-browserify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\stream-browserify
 │  └─ licenseFile: node_modules\stream-browserify\LICENSE
 ├─ stream-each@1.2.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/stream-each
 │  ├─ publisher: Mathias Buus
 │  ├─ url: @mafintosh
-│  ├─ path: C:\dev\dnn-elements\node_modules\stream-each
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\stream-each
 │  └─ licenseFile: node_modules\stream-each\LICENSE
 ├─ stream-http@2.8.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jhiesey/stream-http
 │  ├─ publisher: John Hiesey
-│  ├─ path: C:\dev\dnn-elements\node_modules\stream-http
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\stream-http
 │  └─ licenseFile: node_modules\stream-http\LICENSE
 ├─ stream-shift@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/stream-shift
 │  ├─ publisher: Mathias Buus
 │  ├─ url: @mafintosh
-│  ├─ path: C:\dev\dnn-elements\node_modules\stream-shift
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\stream-shift
 │  └─ licenseFile: node_modules\stream-shift\LICENSE
 ├─ string-length@4.0.2
 │  ├─ licenses: MIT
@@ -7314,7 +7331,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\string-length
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\string-length
 │  └─ licenseFile: node_modules\string-length\license
 ├─ string-width@4.2.3
 │  ├─ licenses: MIT
@@ -7322,47 +7339,47 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\string-width
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\string-width
 │  └─ licenseFile: node_modules\string-width\license
 ├─ string.prototype.matchall@4.0.6
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/String.prototype.matchAll
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\string.prototype.matchall
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\string.prototype.matchall
 │  └─ licenseFile: node_modules\string.prototype.matchall\LICENSE
 ├─ string.prototype.padend@3.1.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/String.prototype.padEnd
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\string.prototype.padend
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\string.prototype.padend
 │  └─ licenseFile: node_modules\string.prototype.padend\LICENSE
 ├─ string.prototype.padstart@3.1.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/String.prototype.padStart
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\string.prototype.padstart
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\string.prototype.padstart
 │  └─ licenseFile: node_modules\string.prototype.padstart\LICENSE
 ├─ string.prototype.trimend@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/String.prototype.trimEnd
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\string.prototype.trimend
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\string.prototype.trimend
 │  └─ licenseFile: node_modules\string.prototype.trimend\LICENSE
 ├─ string.prototype.trimstart@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/String.prototype.trimStart
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\string.prototype.trimstart
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\string.prototype.trimstart
 │  └─ licenseFile: node_modules\string.prototype.trimstart\LICENSE
 ├─ string_decoder@1.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/nodejs/string_decoder
-│  ├─ path: C:\dev\dnn-elements\node_modules\string_decoder
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\string_decoder
 │  └─ licenseFile: node_modules\string_decoder\LICENSE
 ├─ strip-ansi@6.0.1
 │  ├─ licenses: MIT
@@ -7370,7 +7387,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\strip-ansi
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\strip-ansi
 │  └─ licenseFile: node_modules\strip-ansi\license
 ├─ strip-bom@4.0.0
 │  ├─ licenses: MIT
@@ -7378,7 +7395,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\strip-bom
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\strip-bom
 │  └─ licenseFile: node_modules\strip-bom\license
 ├─ strip-eof@1.0.0
 │  ├─ licenses: MIT
@@ -7386,7 +7403,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\strip-eof
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\strip-eof
 │  └─ licenseFile: node_modules\strip-eof\license
 ├─ strip-final-newline@2.0.0
 │  ├─ licenses: MIT
@@ -7394,7 +7411,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\strip-final-newline
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\strip-final-newline
 │  └─ licenseFile: node_modules\strip-final-newline\license
 ├─ strip-json-comments@3.1.1
 │  ├─ licenses: MIT
@@ -7402,28 +7419,28 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\strip-json-comments
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\strip-json-comments
 │  └─ licenseFile: node_modules\strip-json-comments\license
 ├─ style-loader@1.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack-contrib/style-loader
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\style-loader
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\style-loader
 │  └─ licenseFile: node_modules\style-loader\LICENSE
 ├─ style-to-object@0.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/remarkablemark/style-to-object
 │  ├─ publisher: Mark
 │  ├─ email: mark@remarkablemark.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\style-to-object
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\style-to-object
 │  └─ licenseFile: node_modules\style-to-object\LICENSE
-├─ supports-color@7.2.0
+├─ supports-color@5.5.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/chalk/supports-color
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\supports-color
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\supports-color
 │  └─ licenseFile: node_modules\supports-color\license
 ├─ supports-hyperlinks@2.2.0
 │  ├─ licenses: MIT
@@ -7431,21 +7448,28 @@
 │  ├─ publisher: James Talmage
 │  ├─ email: james@talmage.io
 │  ├─ url: github.com/jamestalmage
-│  ├─ path: C:\dev\dnn-elements\node_modules\supports-hyperlinks
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\supports-hyperlinks
 │  └─ licenseFile: node_modules\supports-hyperlinks\license
+├─ supports-preserve-symlinks-flag@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/node-supports-preserve-symlinks-flag
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\supports-preserve-symlinks-flag
+│  └─ licenseFile: node_modules\supports-preserve-symlinks-flag\LICENSE
 ├─ symbol-tree@3.2.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jsdom/js-symbol-tree
 │  ├─ publisher: Joris van der Wel
 │  ├─ email: joris@jorisvanderwel.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\symbol-tree
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\symbol-tree
 │  └─ licenseFile: node_modules\symbol-tree\LICENSE
 ├─ symbol.prototype.description@1.0.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/Symbol.prototype.description
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\symbol.prototype.description
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\symbol.prototype.description
 │  └─ licenseFile: node_modules\symbol.prototype.description\LICENSE
 ├─ synchronous-promise@2.0.15
 │  ├─ licenses: BSD-3-Clause
@@ -7453,34 +7477,34 @@
 │  ├─ publisher: Davyd McColl
 │  ├─ email: davydm@gmail.com
 │  ├─ url: https://github.com/fluffynuts
-│  ├─ path: C:\dev\dnn-elements\node_modules\synchronous-promise
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\synchronous-promise
 │  └─ licenseFile: node_modules\synchronous-promise\LICENSE
-├─ table@6.7.5
+├─ table@6.8.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/gajus/table
 │  ├─ publisher: Gajus Kuizinas
 │  ├─ email: gajus@gajus.com
 │  ├─ url: http://gajus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\table
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\table
 │  └─ licenseFile: node_modules\table\LICENSE
 ├─ tapable@1.1.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/tapable
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\tapable
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\tapable
 │  └─ licenseFile: node_modules\tapable\LICENSE
 ├─ tar-fs@2.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/tar-fs
 │  ├─ publisher: Mathias Buus
-│  ├─ path: C:\dev\dnn-elements\node_modules\tar-fs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\tar-fs
 │  └─ licenseFile: node_modules\tar-fs\LICENSE
 ├─ tar-stream@2.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/tar-stream
 │  ├─ publisher: Mathias Buus
 │  ├─ email: mathiasbuus@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\tar-stream
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\tar-stream
 │  └─ licenseFile: node_modules\tar-stream\LICENSE
 ├─ tar@6.1.11
 │  ├─ licenses: ISC
@@ -7488,12 +7512,12 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\tar
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\tar
 │  └─ licenseFile: node_modules\tar\LICENSE
 ├─ telejson@5.3.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/storybooks/telejson
-│  ├─ path: C:\dev\dnn-elements\node_modules\telejson
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\telejson
 │  └─ licenseFile: node_modules\telejson\README.md
 ├─ terminal-link@2.1.1
 │  ├─ licenses: MIT
@@ -7501,13 +7525,13 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\terminal-link
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\terminal-link
 │  └─ licenseFile: node_modules\terminal-link\license
-├─ terser-webpack-plugin@4.2.3
+├─ terser-webpack-plugin@1.4.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack-contrib/terser-webpack-plugin
 │  ├─ publisher: webpack Contrib Team
-│  ├─ path: C:\dev\dnn-elements\node_modules\terser-webpack-plugin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\terser-webpack-plugin
 │  └─ licenseFile: node_modules\terser-webpack-plugin\LICENSE
 ├─ terser@4.8.0
 │  ├─ licenses: BSD-2-Clause
@@ -7515,14 +7539,14 @@
 │  ├─ publisher: Mihai Bazon
 │  ├─ email: mihai.bazon@gmail.com
 │  ├─ url: http://lisperator.net/
-│  ├─ path: C:\dev\dnn-elements\node_modules\terser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\terser
 │  └─ licenseFile: node_modules\terser\LICENSE
 ├─ test-exclude@6.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/istanbuljs/test-exclude
 │  ├─ publisher: Ben Coe
 │  ├─ email: ben@npmjs.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\test-exclude
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\test-exclude
 │  └─ licenseFile: node_modules\test-exclude\LICENSE.txt
 ├─ text-table@0.2.0
 │  ├─ licenses: MIT
@@ -7530,13 +7554,13 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\text-table
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\text-table
 │  └─ licenseFile: node_modules\text-table\LICENSE
 ├─ throat@6.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ForbesLindesay/throat
 │  ├─ publisher: ForbesLindesay
-│  ├─ path: C:\dev\dnn-elements\node_modules\throat
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\throat
 │  └─ licenseFile: node_modules\throat\LICENSE
 ├─ throttle-debounce@3.0.1
 │  ├─ licenses: MIT
@@ -7544,7 +7568,7 @@
 │  ├─ publisher: Ivan Nikolić
 │  ├─ email: niksy5@gmail.com
 │  ├─ url: http://ivannikolic.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\throttle-debounce
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\throttle-debounce
 │  └─ licenseFile: node_modules\throttle-debounce\LICENSE.md
 ├─ through2@2.0.5
 │  ├─ licenses: MIT
@@ -7552,7 +7576,7 @@
 │  ├─ publisher: Rod Vagg
 │  ├─ email: r@va.gg
 │  ├─ url: https://github.com/rvagg
-│  ├─ path: C:\dev\dnn-elements\node_modules\through2
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\through2
 │  └─ licenseFile: node_modules\through2\LICENSE.md
 ├─ through@2.3.8
 │  ├─ licenses: MIT
@@ -7560,7 +7584,7 @@
 │  ├─ publisher: Dominic Tarr
 │  ├─ email: dominic.tarr@gmail.com
 │  ├─ url: dominictarr.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\through
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\through
 │  └─ licenseFile: node_modules\through\LICENSE.APACHE2
 ├─ timers-browserify@2.0.12
 │  ├─ licenses: MIT
@@ -7568,26 +7592,26 @@
 │  ├─ publisher: J. Ryan Stinnett
 │  ├─ email: jryans@gmail.com
 │  ├─ url: https://convolv.es/
-│  ├─ path: C:\dev\dnn-elements\node_modules\timers-browserify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\timers-browserify
 │  └─ licenseFile: node_modules\timers-browserify\LICENSE.md
 ├─ tiny-emitter@2.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/scottcorgan/tiny-emitter
 │  ├─ publisher: Scott Corgan
-│  ├─ path: C:\dev\dnn-elements\node_modules\tiny-emitter
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\tiny-emitter
 │  └─ licenseFile: node_modules\tiny-emitter\LICENSE
 ├─ tmpl@1.0.5
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/daaku/nodejs-tmpl
 │  ├─ publisher: Naitik Shah
 │  ├─ email: n@daaku.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\tmpl
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\tmpl
 │  └─ licenseFile: node_modules\tmpl\license
 ├─ to-arraybuffer@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jhiesey/to-arraybuffer
 │  ├─ publisher: John Hiesey
-│  ├─ path: C:\dev\dnn-elements\node_modules\to-arraybuffer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\to-arraybuffer
 │  └─ licenseFile: node_modules\to-arraybuffer\LICENSE
 ├─ to-fast-properties@2.0.0
 │  ├─ licenses: MIT
@@ -7595,28 +7619,28 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\to-fast-properties
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\to-fast-properties
 │  └─ licenseFile: node_modules\to-fast-properties\license
 ├─ to-object-path@0.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/to-object-path
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\to-object-path
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\to-object-path
 │  └─ licenseFile: node_modules\to-object-path\LICENSE
 ├─ to-regex-range@5.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/micromatch/to-regex-range
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\to-regex-range
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\to-regex-range
 │  └─ licenseFile: node_modules\to-regex-range\LICENSE
 ├─ to-regex@3.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/to-regex
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\to-regex
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\to-regex
 │  └─ licenseFile: node_modules\to-regex\LICENSE
 ├─ toggle-selection@1.0.6
 │  ├─ licenses: MIT
@@ -7624,35 +7648,34 @@
 │  ├─ publisher: sudodoki
 │  ├─ email: smd.deluzion@gmail.com
 │  ├─ url: sudodoki.name
-│  ├─ path: C:\dev\dnn-elements\node_modules\toggle-selection
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\toggle-selection
 │  └─ licenseFile: node_modules\toggle-selection\README.md
 ├─ toidentifier@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/component/toidentifier
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\toidentifier
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\toidentifier
 │  └─ licenseFile: node_modules\toidentifier\LICENSE
 ├─ tough-cookie@4.0.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/salesforce/tough-cookie
 │  ├─ publisher: Jeremy Stashewsky
 │  ├─ email: jstash@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\tough-cookie
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\tough-cookie
 │  └─ licenseFile: node_modules\tough-cookie\LICENSE
-├─ tr46@2.1.0
+├─ tr46@0.0.3
 │  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jsdom/tr46
+│  ├─ repository: https://github.com/Sebmaster/tr46.js
 │  ├─ publisher: Sebastian Mayr
 │  ├─ email: npm@smayr.name
-│  ├─ path: C:\dev\dnn-elements\node_modules\tr46
-│  └─ licenseFile: node_modules\tr46\LICENSE.md
+│  └─ path: D:\dnn-elements\dnn-elements\node_modules\tr46
 ├─ treeify@1.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/notatestuser/treeify
 │  ├─ publisher: Luke Plaster
 │  ├─ email: notatestuser@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\treeify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\treeify
 │  └─ licenseFile: node_modules\treeify\LICENSE
 ├─ trim-trailing-lines@1.1.4
 │  ├─ licenses: MIT
@@ -7660,13 +7683,13 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\trim-trailing-lines
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\trim-trailing-lines
 │  └─ licenseFile: node_modules\trim-trailing-lines\license
 ├─ trim@0.0.1
 │  ├─ licenses: MIT*
 │  ├─ publisher: TJ Holowaychuk
 │  ├─ email: tj@vision-media.ca
-│  ├─ path: C:\dev\dnn-elements\node_modules\trim
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\trim
 │  └─ licenseFile: node_modules\trim\Readme.md
 ├─ trough@1.0.5
 │  ├─ licenses: MIT
@@ -7674,31 +7697,31 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\trough
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\trough
 │  └─ licenseFile: node_modules\trough\license
 ├─ ts-dedent@2.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/tamino-martinius/node-ts-dedent
 │  ├─ publisher: Tamino Martinius
 │  ├─ email: dev@zaku.eu
-│  ├─ path: C:\dev\dnn-elements\node_modules\ts-dedent
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ts-dedent
 │  └─ licenseFile: node_modules\ts-dedent\LICENSE
 ├─ ts-pnp@1.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/arcanis/ts-pnp
-│  ├─ path: C:\dev\dnn-elements\node_modules\ts-pnp
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ts-pnp
 │  └─ licenseFile: node_modules\ts-pnp\README.md
-├─ tslib@1.10.0
-│  ├─ licenses: Apache-2.0
+├─ tslib@1.14.1
+│  ├─ licenses: 0BSD
 │  ├─ repository: https://github.com/Microsoft/tslib
 │  ├─ publisher: Microsoft Corp.
-│  ├─ path: C:\dev\dnn-elements\node_modules\tslib
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\tslib
 │  └─ licenseFile: node_modules\tslib\LICENSE.txt
-├─ tsutils@3.21.0
+├─ tsutils@3.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ajafff/tsutils
 │  ├─ publisher: Klaus Meinhardt
-│  ├─ path: C:\dev\dnn-elements\node_modules\tsutils
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\tsutils
 │  └─ licenseFile: node_modules\tsutils\LICENSE
 ├─ tty-browserify@0.0.0
 │  ├─ licenses: MIT
@@ -7706,14 +7729,14 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\tty-browserify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\tty-browserify
 │  └─ licenseFile: node_modules\tty-browserify\LICENSE
 ├─ type-check@0.3.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/gkz/type-check
 │  ├─ publisher: George Zahariev
 │  ├─ email: z@georgezahariev.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\type-check
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\type-check
 │  └─ licenseFile: node_modules\type-check\LICENSE
 ├─ type-detect@4.0.8
 │  ├─ licenses: MIT
@@ -7721,26 +7744,26 @@
 │  ├─ publisher: Jake Luer
 │  ├─ email: jake@alogicalparadox.com
 │  ├─ url: http://alogicalparadox.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\type-detect
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\type-detect
 │  └─ licenseFile: node_modules\type-detect\LICENSE
-├─ type-fest@0.20.2
+├─ type-fest@0.8.1
 │  ├─ licenses: (MIT OR CC0-1.0)
 │  ├─ repository: https://github.com/sindresorhus/type-fest
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\type-fest
+│  ├─ url: sindresorhus.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\type-fest
 │  └─ licenseFile: node_modules\type-fest\license
 ├─ type-is@1.6.18
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/type-is
-│  ├─ path: C:\dev\dnn-elements\node_modules\type-is
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\type-is
 │  └─ licenseFile: node_modules\type-is\LICENSE
 ├─ typed-styles@0.0.7
 │  ├─ licenses: MIT
 │  ├─ publisher: lttb
 │  ├─ email: kenzhaev.artur@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\typed-styles
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\typed-styles
 │  └─ licenseFile: node_modules\typed-styles\LICENSE
 ├─ typedarray-to-buffer@3.1.5
 │  ├─ licenses: MIT
@@ -7748,7 +7771,7 @@
 │  ├─ publisher: Feross Aboukhadijeh
 │  ├─ email: feross@feross.org
 │  ├─ url: http://feross.org/
-│  ├─ path: C:\dev\dnn-elements\node_modules\typedarray-to-buffer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\typedarray-to-buffer
 │  └─ licenseFile: node_modules\typedarray-to-buffer\LICENSE
 ├─ typedarray@0.0.6
 │  ├─ licenses: MIT
@@ -7756,19 +7779,19 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\typedarray
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\typedarray
 │  └─ licenseFile: node_modules\typedarray\LICENSE
 ├─ typescript-debounce-decorator@0.0.18
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/duxiaofeng-github/typescript-debounce-decorator
 │  ├─ publisher: duxiaofeng-github
-│  ├─ path: C:\dev\dnn-elements\node_modules\typescript-debounce-decorator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\typescript-debounce-decorator
 │  └─ licenseFile: node_modules\typescript-debounce-decorator\LICENSE
 ├─ typescript@4.6.2
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/Microsoft/TypeScript
 │  ├─ publisher: Microsoft Corp.
-│  ├─ path: C:\dev\dnn-elements\node_modules\typescript
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\typescript
 │  └─ licenseFile: node_modules\typescript\LICENSE.txt
 ├─ uglify-js@3.15.3
 │  ├─ licenses: BSD-2-Clause
@@ -7776,26 +7799,26 @@
 │  ├─ publisher: Mihai Bazon
 │  ├─ email: mihai.bazon@gmail.com
 │  ├─ url: http://lisperator.net/
-│  ├─ path: C:\dev\dnn-elements\node_modules\uglify-js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\uglify-js
 │  └─ licenseFile: node_modules\uglify-js\LICENSE
 ├─ unbox-primitive@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/unbox-primitive
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unbox-primitive
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unbox-primitive
 │  └─ licenseFile: node_modules\unbox-primitive\LICENSE
 ├─ unbzip2-stream@1.4.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/regular/unbzip2-stream
 │  ├─ publisher: Jan Bölsche
 │  ├─ email: jan@lagomorph.de
-│  ├─ path: C:\dev\dnn-elements\node_modules\unbzip2-stream
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unbzip2-stream
 │  └─ licenseFile: node_modules\unbzip2-stream\LICENSE
 ├─ unfetch@4.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/developit/unfetch
-│  ├─ path: C:\dev\dnn-elements\node_modules\unfetch
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unfetch
 │  └─ licenseFile: node_modules\unfetch\LICENSE.md
 ├─ unherit@1.1.3
 │  ├─ licenses: MIT
@@ -7803,35 +7826,35 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unherit
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unherit
 │  └─ licenseFile: node_modules\unherit\license
 ├─ unicode-canonical-property-names-ecmascript@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/unicode-canonical-property-names-ecmascript
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\unicode-canonical-property-names-ecmascript
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unicode-canonical-property-names-ecmascript
 │  └─ licenseFile: node_modules\unicode-canonical-property-names-ecmascript\LICENSE-MIT.txt
 ├─ unicode-match-property-ecmascript@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/unicode-match-property-ecmascript
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\unicode-match-property-ecmascript
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unicode-match-property-ecmascript
 │  └─ licenseFile: node_modules\unicode-match-property-ecmascript\LICENSE-MIT.txt
 ├─ unicode-match-property-value-ecmascript@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/unicode-match-property-value-ecmascript
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\unicode-match-property-value-ecmascript
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unicode-match-property-value-ecmascript
 │  └─ licenseFile: node_modules\unicode-match-property-value-ecmascript\LICENSE-MIT.txt
 ├─ unicode-property-aliases-ecmascript@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/unicode-property-aliases-ecmascript
 │  ├─ publisher: Mathias Bynens
 │  ├─ url: https://mathiasbynens.be/
-│  ├─ path: C:\dev\dnn-elements\node_modules\unicode-property-aliases-ecmascript
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unicode-property-aliases-ecmascript
 │  └─ licenseFile: node_modules\unicode-property-aliases-ecmascript\LICENSE-MIT.txt
 ├─ unified@9.2.0
 │  ├─ licenses: MIT
@@ -7839,14 +7862,14 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unified
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unified
 │  └─ licenseFile: node_modules\unified\license
 ├─ union-value@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/union-value
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\union-value
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\union-value
 │  └─ licenseFile: node_modules\union-value\LICENSE
 ├─ unique-filename@1.1.1
 │  ├─ licenses: ISC
@@ -7854,7 +7877,7 @@
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
 │  ├─ url: http://re-becca.org/
-│  ├─ path: C:\dev\dnn-elements\node_modules\unique-filename
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unique-filename
 │  └─ licenseFile: node_modules\unique-filename\LICENSE
 ├─ unique-slug@2.0.2
 │  ├─ licenses: ISC
@@ -7862,14 +7885,14 @@
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
 │  ├─ url: http://re-becca.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\unique-slug
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unique-slug
 │  └─ licenseFile: node_modules\unique-slug\LICENSE
 ├─ unist-builder@2.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/syntax-tree/unist-builder
 │  ├─ publisher: Eugene Sharygin
 │  ├─ email: eush77@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unist-builder
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unist-builder
 │  └─ licenseFile: node_modules\unist-builder\license
 ├─ unist-util-generated@1.1.6
 │  ├─ licenses: MIT
@@ -7877,7 +7900,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unist-util-generated
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unist-util-generated
 │  └─ licenseFile: node_modules\unist-util-generated\license
 ├─ unist-util-is@4.1.0
 │  ├─ licenses: MIT
@@ -7885,7 +7908,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unist-util-is
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unist-util-is
 │  └─ licenseFile: node_modules\unist-util-is\license
 ├─ unist-util-position@3.1.0
 │  ├─ licenses: MIT
@@ -7893,7 +7916,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unist-util-position
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unist-util-position
 │  └─ licenseFile: node_modules\unist-util-position\license
 ├─ unist-util-remove-position@2.0.1
 │  ├─ licenses: MIT
@@ -7901,14 +7924,14 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unist-util-remove-position
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unist-util-remove-position
 │  └─ licenseFile: node_modules\unist-util-remove-position\license
 ├─ unist-util-remove@2.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/syntax-tree/unist-util-remove
 │  ├─ publisher: Eugene Sharygin
 │  ├─ email: eush77@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unist-util-remove
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unist-util-remove
 │  └─ licenseFile: node_modules\unist-util-remove\license
 ├─ unist-util-stringify-position@2.0.3
 │  ├─ licenses: MIT
@@ -7916,7 +7939,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unist-util-stringify-position
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unist-util-stringify-position
 │  └─ licenseFile: node_modules\unist-util-stringify-position\license
 ├─ unist-util-visit-parents@3.1.1
 │  ├─ licenses: MIT
@@ -7924,7 +7947,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unist-util-visit-parents
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unist-util-visit-parents
 │  └─ licenseFile: node_modules\unist-util-visit-parents\license
 ├─ unist-util-visit@2.0.3
 │  ├─ licenses: MIT
@@ -7932,101 +7955,101 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unist-util-visit
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unist-util-visit
 │  └─ licenseFile: node_modules\unist-util-visit\license
-├─ universalify@0.1.2
+├─ universalify@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/RyanZim/universalify
 │  ├─ publisher: Ryan Zimmerman
 │  ├─ email: opensrc@ryanzim.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\universalify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\universalify
 │  └─ licenseFile: node_modules\universalify\LICENSE
 ├─ unpipe@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/stream-utils/unpipe
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unpipe
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unpipe
 │  └─ licenseFile: node_modules\unpipe\LICENSE
 ├─ unquote@1.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lakenen/node-unquote
 │  ├─ publisher: Cameron Lakenen
 │  ├─ email: cameron@lakenen.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\unquote
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unquote
 │  └─ licenseFile: node_modules\unquote\LICENSE
 ├─ unset-value@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/unset-value
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\unset-value
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unset-value
 │  └─ licenseFile: node_modules\unset-value\LICENSE
 ├─ upath@1.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/anodynos/upath
 │  ├─ publisher: Angelos Pikoulas
 │  ├─ email: agelos.pikoulas@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\upath
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\upath
 │  └─ licenseFile: node_modules\upath\LICENSE
 ├─ uri-js@4.4.1
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/garycourt/uri-js
 │  ├─ publisher: Gary Court
 │  ├─ email: gary.court@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\uri-js
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\uri-js
 │  └─ licenseFile: node_modules\uri-js\LICENSE
 ├─ urix@0.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lydell/urix
 │  ├─ publisher: Simon Lydell
-│  ├─ path: C:\dev\dnn-elements\node_modules\urix
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\urix
 │  └─ licenseFile: node_modules\urix\LICENSE
 ├─ url-loader@4.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack-contrib/url-loader
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\url-loader
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\url-loader
 │  └─ licenseFile: node_modules\url-loader\LICENSE
 ├─ url@0.11.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/defunctzombie/node-url
-│  ├─ path: C:\dev\dnn-elements\node_modules\url
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\url
 │  └─ licenseFile: node_modules\url\LICENSE
 ├─ use-callback-ref@1.2.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/theKashey/use-callback-ref
 │  ├─ publisher: theKashey
 │  ├─ email: thekashey@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\use-callback-ref
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\use-callback-ref
 │  └─ licenseFile: node_modules\use-callback-ref\README.md
 ├─ use-composed-ref@1.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Andarist/use-composed-ref
-│  ├─ path: C:\dev\dnn-elements\node_modules\use-composed-ref
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\use-composed-ref
 │  └─ licenseFile: node_modules\use-composed-ref\README.md
 ├─ use-isomorphic-layout-effect@1.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Andarist/use-isomorphic-layout-effect
-│  ├─ path: C:\dev\dnn-elements\node_modules\use-isomorphic-layout-effect
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\use-isomorphic-layout-effect
 │  └─ licenseFile: node_modules\use-isomorphic-layout-effect\LICENSE
 ├─ use-latest@1.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Andarist/use-latest
-│  ├─ path: C:\dev\dnn-elements\node_modules\use-latest
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\use-latest
 │  └─ licenseFile: node_modules\use-latest\README.md
 ├─ use-sidecar@1.0.5
 │  ├─ licenses: MIT
 │  ├─ publisher: theKashey
 │  ├─ email: thekashey@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\use-sidecar
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\use-sidecar
 │  └─ licenseFile: node_modules\use-sidecar\README.md
 ├─ use@3.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/use
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\use
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\use
 │  └─ licenseFile: node_modules\use\LICENSE
 ├─ util-deprecate@1.0.2
 │  ├─ licenses: MIT
@@ -8034,32 +8057,32 @@
 │  ├─ publisher: Nathan Rajlich
 │  ├─ email: nathan@tootallnate.net
 │  ├─ url: http://n8.io/
-│  ├─ path: C:\dev\dnn-elements\node_modules\util-deprecate
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\util-deprecate
 │  └─ licenseFile: node_modules\util-deprecate\LICENSE
 ├─ util-extend@1.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/isaacs/util-extend
-│  ├─ path: C:\dev\dnn-elements\node_modules\util-extend
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\util-extend
 │  └─ licenseFile: node_modules\util-extend\LICENSE
 ├─ util.promisify@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/util.promisify
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\util.promisify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\util.promisify
 │  └─ licenseFile: node_modules\util.promisify\LICENSE
 ├─ util@0.11.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/defunctzombie/node-util
 │  ├─ publisher: Joyent
 │  ├─ url: http://www.joyent.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\util
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\util
 │  └─ licenseFile: node_modules\util\LICENSE
 ├─ utila@0.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/AriaMinaei/utila
 │  ├─ publisher: Aria Minaei
-│  ├─ path: C:\dev\dnn-elements\node_modules\utila
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\utila
 │  └─ licenseFile: node_modules\utila\LICENSE
 ├─ utils-merge@1.0.1
 │  ├─ licenses: MIT
@@ -8067,33 +8090,33 @@
 │  ├─ publisher: Jared Hanson
 │  ├─ email: jaredhanson@gmail.com
 │  ├─ url: http://www.jaredhanson.net/
-│  ├─ path: C:\dev\dnn-elements\node_modules\utils-merge
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\utils-merge
 │  └─ licenseFile: node_modules\utils-merge\LICENSE
 ├─ uuid-browser@3.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/heikomat/uuid-browser
 │  ├─ publisher: Heiko Mathes
 │  ├─ email: heiko.mathes@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\uuid-browser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\uuid-browser
 │  └─ licenseFile: node_modules\uuid-browser\LICENSE.md
 ├─ uuid@3.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/uuidjs/uuid
-│  ├─ path: C:\dev\dnn-elements\node_modules\uuid
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\uuid
 │  └─ licenseFile: node_modules\uuid\LICENSE.md
 ├─ v8-compile-cache@2.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zertosh/v8-compile-cache
 │  ├─ publisher: Andres Suarez
 │  ├─ email: zertosh@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\v8-compile-cache
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\v8-compile-cache
 │  └─ licenseFile: node_modules\v8-compile-cache\LICENSE
 ├─ v8-to-istanbul@8.1.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/istanbuljs/v8-to-istanbul
 │  ├─ publisher: Ben Coe
 │  ├─ email: ben@npmjs.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\v8-to-istanbul
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\v8-to-istanbul
 │  └─ licenseFile: node_modules\v8-to-istanbul\LICENSE.txt
 ├─ validate-npm-package-license@3.0.4
 │  ├─ licenses: Apache-2.0
@@ -8101,14 +8124,14 @@
 │  ├─ publisher: Kyle E. Mitchell
 │  ├─ email: kyle@kemitchell.com
 │  ├─ url: https://kemitchell.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\validate-npm-package-license
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\validate-npm-package-license
 │  └─ licenseFile: node_modules\validate-npm-package-license\LICENSE
 ├─ vary@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/vary
 │  ├─ publisher: Douglas Christopher Wilson
 │  ├─ email: doug@somethingdoug.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\vary
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\vary
 │  └─ licenseFile: node_modules\vary\LICENSE
 ├─ vfile-location@3.2.0
 │  ├─ licenses: MIT
@@ -8116,7 +8139,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\vfile-location
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\vfile-location
 │  └─ licenseFile: node_modules\vfile-location\license
 ├─ vfile-message@2.0.4
 │  ├─ licenses: MIT
@@ -8124,7 +8147,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\vfile-message
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\vfile-message
 │  └─ licenseFile: node_modules\vfile-message\license
 ├─ vfile@4.2.1
 │  ├─ licenses: MIT
@@ -8132,7 +8155,7 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\vfile
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\vfile
 │  └─ licenseFile: node_modules\vfile\license
 ├─ vm-browserify@1.1.2
 │  ├─ licenses: MIT
@@ -8140,26 +8163,26 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\vm-browserify
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\vm-browserify
 │  └─ licenseFile: node_modules\vm-browserify\LICENSE
 ├─ w3c-hr-time@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jsdom/w3c-hr-time
 │  ├─ publisher: Timothy Gu
 │  ├─ email: timothygu99@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\w3c-hr-time
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\w3c-hr-time
 │  └─ licenseFile: node_modules\w3c-hr-time\LICENSE.md
 ├─ w3c-xmlserializer@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jsdom/w3c-xmlserializer
-│  ├─ path: C:\dev\dnn-elements\node_modules\w3c-xmlserializer
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\w3c-xmlserializer
 │  └─ licenseFile: node_modules\w3c-xmlserializer\LICENSE.md
 ├─ walker@1.0.8
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/daaku/nodejs-walker
 │  ├─ publisher: Naitik Shah
 │  ├─ email: n@daaku.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\walker
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\walker
 │  └─ licenseFile: node_modules\walker\LICENSE
 ├─ warning@4.0.3
 │  ├─ licenses: MIT
@@ -8167,18 +8190,18 @@
 │  ├─ publisher: Berkeley Martinez
 │  ├─ email: berkeley@berkeleytrue.com
 │  ├─ url: http://www.berkeleytrue.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\warning
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\warning
 │  └─ licenseFile: node_modules\warning\LICENSE.md
 ├─ watchpack-chokidar2@2.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/watchpack
 │  ├─ publisher: Tobias Koppers @sokra
-│  └─ path: C:\dev\dnn-elements\node_modules\watchpack-chokidar2
-├─ watchpack@2.3.1
+│  └─ path: D:\dnn-elements\dnn-elements\node_modules\watchpack-chokidar2
+├─ watchpack@1.7.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/watchpack
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\watchpack
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\watchpack
 │  └─ licenseFile: node_modules\watchpack\LICENSE
 ├─ web-namespaces@1.1.4
 │  ├─ licenses: MIT
@@ -8186,59 +8209,59 @@
 │  ├─ publisher: Titus Wormer
 │  ├─ email: tituswormer@gmail.com
 │  ├─ url: https://wooorm.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\web-namespaces
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\web-namespaces
 │  └─ licenseFile: node_modules\web-namespaces\license
-├─ webidl-conversions@6.1.0
+├─ webidl-conversions@3.0.1
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/jsdom/webidl-conversions
 │  ├─ publisher: Domenic Denicola
 │  ├─ email: d@domenic.me
 │  ├─ url: https://domenic.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\webidl-conversions
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\webidl-conversions
 │  └─ licenseFile: node_modules\webidl-conversions\LICENSE.md
 ├─ webpack-dev-middleware@3.7.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/webpack-dev-middleware
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\webpack-dev-middleware
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\webpack-dev-middleware
 │  └─ licenseFile: node_modules\webpack-dev-middleware\LICENSE
 ├─ webpack-filter-warnings-plugin@1.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mattlewis92/webpack-filter-warnings-plugin
 │  ├─ publisher: Matt Lewis
-│  ├─ path: C:\dev\dnn-elements\node_modules\webpack-filter-warnings-plugin
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\webpack-filter-warnings-plugin
 │  └─ licenseFile: node_modules\webpack-filter-warnings-plugin\LICENSE
 ├─ webpack-hot-middleware@2.25.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack-contrib/webpack-hot-middleware
 │  ├─ publisher: Glen Mailer
 │  ├─ email: glen@stainlessed.co.uk
-│  ├─ path: C:\dev\dnn-elements\node_modules\webpack-hot-middleware
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\webpack-hot-middleware
 │  └─ licenseFile: node_modules\webpack-hot-middleware\LICENSE
 ├─ webpack-log@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack-contrib/webpack-log
 │  ├─ publisher: Andrew Powell
 │  ├─ email: andrew@shellscape.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\webpack-log
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\webpack-log
 │  └─ licenseFile: node_modules\webpack-log\LICENSE
 ├─ webpack-sources@1.4.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/webpack-sources
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\webpack-sources
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\webpack-sources
 │  └─ licenseFile: node_modules\webpack-sources\LICENSE
 ├─ webpack-virtual-modules@0.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sysgears/webpack-virtual-modules
 │  ├─ publisher: SysGears INC
-│  ├─ path: C:\dev\dnn-elements\node_modules\webpack-virtual-modules
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\webpack-virtual-modules
 │  └─ licenseFile: node_modules\webpack-virtual-modules\LICENSE
 ├─ webpack@4.46.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/webpack/webpack
 │  ├─ publisher: Tobias Koppers @sokra
-│  ├─ path: C:\dev\dnn-elements\node_modules\webpack
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\webpack
 │  └─ licenseFile: node_modules\webpack\LICENSE
 ├─ whatwg-encoding@1.0.5
 │  ├─ licenses: MIT
@@ -8246,7 +8269,7 @@
 │  ├─ publisher: Domenic Denicola
 │  ├─ email: d@domenic.me
 │  ├─ url: https://domenic.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\whatwg-encoding
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\whatwg-encoding
 │  └─ licenseFile: node_modules\whatwg-encoding\LICENSE.txt
 ├─ whatwg-mimetype@2.3.0
 │  ├─ licenses: MIT
@@ -8254,29 +8277,29 @@
 │  ├─ publisher: Domenic Denicola
 │  ├─ email: d@domenic.me
 │  ├─ url: https://domenic.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\whatwg-mimetype
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\whatwg-mimetype
 │  └─ licenseFile: node_modules\whatwg-mimetype\LICENSE.txt
-├─ whatwg-url@8.7.0
+├─ whatwg-url@5.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jsdom/whatwg-url
 │  ├─ publisher: Sebastian Mayr
 │  ├─ email: github@smayr.name
-│  ├─ path: C:\dev\dnn-elements\node_modules\whatwg-url
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\whatwg-url
 │  └─ licenseFile: node_modules\whatwg-url\LICENSE.txt
 ├─ which-boxed-primitive@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/which-boxed-primitive
 │  ├─ publisher: Jordan Harband
 │  ├─ email: ljharb@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\which-boxed-primitive
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\which-boxed-primitive
 │  └─ licenseFile: node_modules\which-boxed-primitive\LICENSE
-├─ which@2.0.2
+├─ which@1.3.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/node-which
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me
-│  ├─ path: C:\dev\dnn-elements\node_modules\which
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\which
 │  └─ licenseFile: node_modules\which\LICENSE
 ├─ wide-align@1.1.5
 │  ├─ licenses: ISC
@@ -8284,7 +8307,7 @@
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
 │  ├─ url: http://re-becca.org/
-│  ├─ path: C:\dev\dnn-elements\node_modules\wide-align
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\wide-align
 │  └─ licenseFile: node_modules\wide-align\LICENSE
 ├─ widest-line@3.1.0
 │  ├─ licenses: MIT
@@ -8292,14 +8315,14 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\widest-line
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\widest-line
 │  └─ licenseFile: node_modules\widest-line\license
 ├─ word-wrap@1.2.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/word-wrap
 │  ├─ publisher: Jon Schlinkert
 │  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: C:\dev\dnn-elements\node_modules\word-wrap
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\word-wrap
 │  └─ licenseFile: node_modules\word-wrap\LICENSE
 ├─ wordwrap@1.0.0
 │  ├─ licenses: MIT
@@ -8307,12 +8330,12 @@
 │  ├─ publisher: James Halliday
 │  ├─ email: mail@substack.net
 │  ├─ url: http://substack.net
-│  ├─ path: C:\dev\dnn-elements\node_modules\wordwrap
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\wordwrap
 │  └─ licenseFile: node_modules\wordwrap\LICENSE
 ├─ worker-farm@1.7.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/rvagg/node-worker-farm
-│  ├─ path: C:\dev\dnn-elements\node_modules\worker-farm
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\worker-farm
 │  └─ licenseFile: node_modules\worker-farm\LICENSE.md
 ├─ worker-rpc@0.1.1
 │  ├─ licenses: MIT
@@ -8320,7 +8343,7 @@
 │  ├─ publisher: Christian Speckner
 │  ├─ email: cnspeckn@googlemail.com
 │  ├─ url: https://github.com/DirtyHairy/
-│  ├─ path: C:\dev\dnn-elements\node_modules\worker-rpc
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\worker-rpc
 │  └─ licenseFile: node_modules\worker-rpc\LICENSE
 ├─ wrap-ansi@7.0.0
 │  ├─ licenses: MIT
@@ -8328,7 +8351,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\wrap-ansi
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\wrap-ansi
 │  └─ licenseFile: node_modules\wrap-ansi\license
 ├─ wrappy@1.0.2
 │  ├─ licenses: ISC
@@ -8336,7 +8359,7 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\wrappy
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\wrappy
 │  └─ licenseFile: node_modules\wrappy\LICENSE
 ├─ write-file-atomic@3.0.3
 │  ├─ licenses: ISC
@@ -8344,15 +8367,15 @@
 │  ├─ publisher: Rebecca Turner
 │  ├─ email: me@re-becca.org
 │  ├─ url: http://re-becca.org
-│  ├─ path: C:\dev\dnn-elements\node_modules\write-file-atomic
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\write-file-atomic
 │  └─ licenseFile: node_modules\write-file-atomic\LICENSE
-├─ ws@7.5.5
+├─ ws@8.5.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/websockets/ws
 │  ├─ publisher: Einar Otto Stangvik
 │  ├─ email: einaros@gmail.com
 │  ├─ url: http://2x.io
-│  ├─ path: C:\dev\dnn-elements\node_modules\ws
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ws
 │  └─ licenseFile: node_modules\ws\LICENSE
 ├─ xml-name-validator@3.0.0
 │  ├─ licenses: Apache-2.0
@@ -8360,28 +8383,28 @@
 │  ├─ publisher: Domenic Denicola
 │  ├─ email: d@domenic.me
 │  ├─ url: https://domenic.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\xml-name-validator
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\xml-name-validator
 │  └─ licenseFile: node_modules\xml-name-validator\LICENSE.txt
 ├─ xmlchars@2.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lddubeau/xmlchars
 │  ├─ publisher: Louis-Dominique Dubeau
 │  ├─ email: ldd@lddubeau.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\xmlchars
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\xmlchars
 │  └─ licenseFile: node_modules\xmlchars\LICENSE
 ├─ xtend@4.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Raynos/xtend
 │  ├─ publisher: Raynos
 │  ├─ email: raynos2@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\xtend
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\xtend
 │  └─ licenseFile: node_modules\xtend\LICENSE
-├─ y18n@5.0.8
+├─ y18n@4.0.3
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/yargs/y18n
 │  ├─ publisher: Ben Coe
-│  ├─ email: bencoe@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\y18n
+│  ├─ email: ben@npmjs.com
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\y18n
 │  └─ licenseFile: node_modules\y18n\LICENSE
 ├─ yallist@4.0.0
 │  ├─ licenses: ISC
@@ -8389,33 +8412,33 @@
 │  ├─ publisher: Isaac Z. Schlueter
 │  ├─ email: i@izs.me
 │  ├─ url: http://blog.izs.me/
-│  ├─ path: C:\dev\dnn-elements\node_modules\yallist
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\yallist
 │  └─ licenseFile: node_modules\yallist\LICENSE
 ├─ yaml@1.10.2
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/eemeli/yaml
 │  ├─ publisher: Eemeli Aro
 │  ├─ email: eemeli@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\yaml
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\yaml
 │  └─ licenseFile: node_modules\yaml\LICENSE
 ├─ yargs-parser@20.2.9
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/yargs/yargs-parser
 │  ├─ publisher: Ben Coe
 │  ├─ email: ben@npmjs.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\yargs-parser
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\yargs-parser
 │  └─ licenseFile: node_modules\yargs-parser\LICENSE.txt
 ├─ yargs@16.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/yargs/yargs
-│  ├─ path: C:\dev\dnn-elements\node_modules\yargs
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\yargs
 │  └─ licenseFile: node_modules\yargs\LICENSE
 ├─ yauzl@2.10.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/thejoshwolfe/yauzl
 │  ├─ publisher: Josh Wolfe
 │  ├─ email: thejoshwolfe@gmail.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\yauzl
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\yauzl
 │  └─ licenseFile: node_modules\yauzl\LICENSE
 ├─ yocto-queue@0.1.0
 │  ├─ licenses: MIT
@@ -8423,7 +8446,7 @@
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
 │  ├─ url: https://sindresorhus.com
-│  ├─ path: C:\dev\dnn-elements\node_modules\yocto-queue
+│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\yocto-queue
 │  └─ licenseFile: node_modules\yocto-queue\license
 └─ zwitch@1.0.5
    ├─ licenses: MIT
@@ -8431,5 +8454,5 @@
    ├─ publisher: Titus Wormer
    ├─ email: tituswormer@gmail.com
    ├─ url: https://wooorm.com
-   ├─ path: C:\dev\dnn-elements\node_modules\zwitch
+   ├─ path: D:\dnn-elements\dnn-elements\node_modules\zwitch
    └─ licenseFile: node_modules\zwitch\license

--- a/src/components/dnn-vertical-overflow-menu/dnn-vertical-overflow-menu.scss
+++ b/src/components/dnn-vertical-overflow-menu/dnn-vertical-overflow-menu.scss
@@ -1,9 +1,10 @@
 :host {
   /**
-    * @prop --background-color:  Defines the menu background color
-    * @prop --foreground-color: A color that contrasts with the background color
-    * @prop --text-color: The color of the text
+    * @prop --background-color:  Defines the menu background color.
+    * @prop --foreground-color: A color that contrasts with the background color.
   */
+  --background-color: var(--dnn-color-primary-contrast, white);
+  --foreground-color: var(--dnn-color-primary, #3792ED);
 
   display: block;
 }
@@ -12,8 +13,7 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  background-color: var(--background-color, var(--dnn-color-primary-contrast, white));
-  color: var(--text-color, #222);
+  background-color: var(--background-color);
   .menu{
     margin: 0.5em;
     display: flex;
@@ -29,21 +29,12 @@
     button{
       cursor: pointer;
       svg{
-        fill: var(--foreground-color, var(--dnn-color-primary, blue));
+        fill: var(--foreground-color);
       }
       padding: 0;
       margin: 0;
       background-color: transparent;
       border: none;
-    }
-    a.dropdown{
-      span{
-        color: var(--text-color, #222);
-        text-decoration: none;
-        &:hover{
-          color: var(--text-color, #222);
-        }
-      }
     }
     .dropdown{
       position:absolute;
@@ -57,7 +48,7 @@
       &.visible{
         padding: 1em;
         gap: 0.5em;
-        background-color: var(--background-color, var(--dnn-color-primary-contrast, white));
+        background-color: var(--background-color);
         box-shadow: 2px 2px 4px rgba(0,0,0,0.7);
       }
     }

--- a/src/components/dnn-vertical-overflow-menu/dnn-vertical-overflow-menu.stories.ts
+++ b/src/components/dnn-vertical-overflow-menu/dnn-vertical-overflow-menu.stories.ts
@@ -16,15 +16,15 @@ export default {
         '--foreground-color': {
             control: 'color',
         },
-        '--text-color': {
-            control: 'color',
-        },
     }
 } as Meta;
 
 const Template = (args: {}, context) => 
     html`
 <style type="text/css">
+    dnn-vertical-overflow-menu svg{
+        fill: #3792ED;
+    }
     dnn-vertical-overflow-menu button{
         display: flex;
         align-items: center;
@@ -32,6 +32,8 @@ const Template = (args: {}, context) =>
     dnn-vertical-overflow-menu a{
         display: flex;
         align-items: center;
+        text-decoration: none;
+        color: black;
     }
 </style>
 <dnn-vertical-overflow-menu

--- a/src/components/dnn-vertical-overflow-menu/dnn-vertical-overflow-menu.tsx
+++ b/src/components/dnn-vertical-overflow-menu/dnn-vertical-overflow-menu.tsx
@@ -96,9 +96,11 @@ export class DnnVerticalOverflowMenu {
       let contentHeight = 0;
       const items = Array.from(this.dropdown.querySelector("slot").assignedElements());
       items.forEach(item => contentHeight += item.getBoundingClientRect().height);
-      var emHeight = parseFloat(getComputedStyle(this.dropdown).fontSize) * 0.5;
-      var additionalHeight = emHeight * (this.dropdown.children.length - 1);
-      contentHeight += additionalHeight;
+      const emHeight = parseFloat(getComputedStyle(this.dropdown).fontSize);
+      const gapsHeight = emHeight * (this.dropdown.children.length - 1) / 2;
+      contentHeight += gapsHeight;
+      const marginHeight = emHeight * 2;
+      contentHeight += marginHeight;
       this.dropdown.style.height = `${contentHeight}px`;
       const dismissMenu = (e: MouseEvent) => {
         const buttonRect = this.button.getBoundingClientRect();

--- a/src/components/dnn-vertical-overflow-menu/readme.md
+++ b/src/components/dnn-vertical-overflow-menu/readme.md
@@ -7,11 +7,10 @@
 
 ## CSS Custom Properties
 
-| Name                 | Description                                      |
-| -------------------- | ------------------------------------------------ |
-| `--background-color` | Defines the menu background color                |
-| `--foreground-color` | A color that contrasts with the background color |
-| `--text-color`       | The color of the text                            |
+| Name                 | Description                                       |
+| -------------------- | ------------------------------------------------- |
+| `--background-color` | Defines the menu background color.                |
+| `--foreground-color` | A color that contrasts with the background color. |
 
 
 ----------------------------------------------


### PR DESCRIPTION
Ok, so the idea is that any item in the component can be a button, a link or anything, for instance another custom element. For that reason we do not want to style those items ourselves inside the component as the external styles do apply to slotted elements. This PR adjusts a couple of things:
- It brings the consumed CSS variables declarations and fall on the top of the scss file (I have seen this pattern in Ionic quite often and kinda like it because you have a nice overview and it simplifies all the rest of their usage instead of callback declared on each usage).
- It removes the added styles in the scss file
- It removes the --text-color customization as really it did not apply anyway, slotted content uses the styles defined externally
- It adjusts the story for a better example of usage with custom slotted content with their own styles, which might be easier to figure out how to use.